### PR TITLE
Assert all

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # :rocket: nf-test
 
 > Simple test framework for Nextflow pipelines
+The full documentation can be found [here](https://code.askimed.com/nf-test).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # :rocket: nf-test
 
 > Simple test framework for Nextflow pipelines
+
 The full documentation can be found [here](https://code.askimed.com/nf-test).
 
 ## Installation

--- a/docs/assertions/assertions.md
+++ b/docs/assertions/assertions.md
@@ -29,3 +29,38 @@ with(process.out.imputed_plink2) {
     }
 }
 ```
+
+## Using `assertAll`
+`assertAll(Closure... closures)` ensures that all supplied closures do no throw exceptions. The number of failed closures is reported in the Exception message. This useful for efficient debugging
+a set of test assertions in one go.
+
+```groovy
+def a = 2
+
+assertAll(
+	{ assert a==1 },
+	{ a = 1/0 },
+	{ assert a==2 },
+	{ assert a==3 }
+)
+```
+The output will look like this:
+```groovy
+
+assert a==1
+       ||
+       |false
+       2
+
+java.lang.ArithmeticException: Division by zero
+Assertion failed:
+
+assert a==3
+       ||
+       |false
+       2
+
+FAILED (7.106s)
+
+  java.lang.Exception: 3 of 4 assertions failed
+```

--- a/example/hello.nf.test
+++ b/example/hello.nf.test
@@ -6,9 +6,13 @@ nextflow_pipeline {
   test("hello world example should start 4 processes") {
 
     expect {
-      assert workflow.success
-		assert snapshot(workflow).match()
-
+      def a = 2
+      assertAll(
+        { assert a==1 },
+        { a = 1/0 },
+        { assert a==2 },
+        { assert a==3 }
+)
     }
 
   }

--- a/example/hello.nf.test
+++ b/example/hello.nf.test
@@ -6,13 +6,9 @@ nextflow_pipeline {
   test("hello world example should start 4 processes") {
 
     expect {
-      def a = 2
-      assertAll(
-        { assert a==1 },
-        { a = 1/0 },
-        { assert a==2 },
-        { assert a==3 }
-)
+      assert workflow.success
+		assert snapshot(workflow).match()
+
     }
 
   }

--- a/src/main/java/com/askimed/nf/test/lang/extensions/GlobalMethods.java
+++ b/src/main/java/com/askimed/nf/test/lang/extensions/GlobalMethods.java
@@ -21,4 +21,24 @@ public class GlobalMethods {
 		closure.setResolveStrategy(Closure.DELEGATE_FIRST);
 		closure.call();
 	}
+
+	public static void assertAll(Closure... closures) throws Exception {
+		// Asserts that all supplied closures do not throw exceptions.
+		// The number of failed closures is reported in the Exception message
+		int failed = 0;
+
+		for (Closure closure : closures) {
+			try {
+				closure.call();
+			}
+			catch (Throwable e) {
+				failed++;
+				System.out.println(e);
+			}
+		}
+
+		if (failed > 0) {
+			throw new Exception(Integer.toString(failed) + " of " + Integer.toString(closures.length) + " assertions failed");
+		}
+	}
 }

--- a/src/main/java/com/askimed/nf/test/lang/extensions/GlobalMethods.java
+++ b/src/main/java/com/askimed/nf/test/lang/extensions/GlobalMethods.java
@@ -33,7 +33,7 @@ public class GlobalMethods {
 			}
 			catch (Throwable e) {
 				failed++;
-				System.out.println(e);
+				System.err.println(e);
 			}
 		}
 

--- a/src/test/java/com/askimed/nf/test/lang/extensions/GlobalMethodsTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/extensions/GlobalMethodsTest.java
@@ -13,8 +13,8 @@ import groovy.lang.GroovyShell;
 
 public class GlobalMethodsTest {
 
-	@Test
-	public void testAssertAll() throws Exception {
+    @Test
+    public void testAssertAll() throws Exception {
         // Prepare groovy shell with GlobalMethods class
         ImportCustomizer customizer = new ImportCustomizer();
         customizer.addStaticStars("com.askimed.nf.test.lang.extensions.GlobalMethods");
@@ -31,5 +31,5 @@ public class GlobalMethodsTest {
 
         // Assert the message
         assertTrue(exception.toString().contains("3 of 4 assertions failed"));
-	}
+    }
 }

--- a/src/test/java/com/askimed/nf/test/lang/extensions/GlobalMethodsTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/extensions/GlobalMethodsTest.java
@@ -1,22 +1,15 @@
 package com.askimed.nf.test.lang.extensions;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
+
 import org.junit.jupiter.api.Test;
-
-import com.askimed.nf.test.lang.extensions.GlobalMethods;
-import org.codehaus.groovy.control.customizers.ImportCustomizer;
-import org.codehaus.groovy.control.CompilerConfiguration;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import static org.junit.matchers.JUnitMatchers.*;
 import static org.junit.Assert.*;
 
-import groovy.lang.GroovyObjectSupport;
+import org.codehaus.groovy.control.customizers.ImportCustomizer;
+import org.codehaus.groovy.control.CompilerConfiguration;
+
 import groovy.lang.GroovyShell;
-import groovy.lang.GroovyClassLoader;
-import groovy.lang.GroovyObject;
-import groovy.lang.Binding;
 
 public class GlobalMethodsTest {
 
@@ -37,6 +30,6 @@ public class GlobalMethodsTest {
         });
 
         // Assert the message
-        assertThat(exception.toString(), containsString("3 of 4 assertions failed"));
+        assertTrue(exception.toString().contains("3 of 4 assertions failed"));
 	}
 }

--- a/src/test/java/com/askimed/nf/test/lang/extensions/GlobalMethodsTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/extensions/GlobalMethodsTest.java
@@ -1,0 +1,42 @@
+package com.askimed.nf.test.lang.extensions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+
+import com.askimed.nf.test.lang.extensions.GlobalMethods;
+import org.codehaus.groovy.control.customizers.ImportCustomizer;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.junit.matchers.JUnitMatchers.*;
+import static org.junit.Assert.*;
+
+import groovy.lang.GroovyObjectSupport;
+import groovy.lang.GroovyShell;
+import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyObject;
+import groovy.lang.Binding;
+
+public class GlobalMethodsTest {
+
+	@Test
+	public void testAssertAll() throws Exception {
+        // Prepare groovy shell with GlobalMethods class
+        ImportCustomizer customizer = new ImportCustomizer();
+        customizer.addStaticStars("com.askimed.nf.test.lang.extensions.GlobalMethods");
+
+        CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
+        compilerConfiguration.addCompilationCustomizers(customizer);
+
+        GroovyShell shell = new GroovyShell(compilerConfiguration);
+
+        // Run groovy script
+        Exception exception = assertThrows(Exception.class, () -> {
+            Object object = shell.evaluate(new File("./test-data/assertAll.groovy"));
+        });
+
+        // Assert the message
+        assertThat(exception.toString(), containsString("3 of 4 assertions failed"));
+	}
+}

--- a/test-data/assertAll.groovy
+++ b/test-data/assertAll.groovy
@@ -1,5 +1,5 @@
 // Example for the GlobalMethodsTest
-a = 2
+def a = 2
 
 assertAll(
 	{ assert a==1 },

--- a/test-data/assertAll.groovy
+++ b/test-data/assertAll.groovy
@@ -1,0 +1,9 @@
+// Example for the GlobalMethodsTest
+a = 2
+
+assertAll(
+	{ assert a==1 },
+	{ a = 1/0 },
+	{ assert a==2 },
+	{ assert a==3 }
+)

--- a/test-data/assertAll.groovy
+++ b/test-data/assertAll.groovy
@@ -2,8 +2,8 @@
 def a = 2
 
 assertAll(
-	{ assert a==1 },
-	{ a = 1/0 },
-	{ assert a==2 },
-	{ assert a==3 }
+    { assert a==1 },
+    { a = 1/0 },
+    { assert a==2 },
+    { assert a==3 }
 )


### PR DESCRIPTION
An `assertAll` method. Like JUnit's assertAll but for groovy closures:
- added link to full documentation at the top of the readme
- Updated `assertions.md` with info on how to use
- Added an `assertAll` method to GlobalMethods
- Added a unit test for `assertAll`

Fixes: https://github.com/askimed/nf-test/issues/43