### PR TITLE
Add possibility to disable auto-sort for channels

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,9 @@ config {
     // run all test with the defined docker profile from the main nextflow.config
     profile "docker"
     // disable tracing options in case container does not include `procps` Linux tool.
-    withTrace = false
-
+    withTrace false
+    //disable sorted channels
+    autoSort false
 }
 ```
 
@@ -49,13 +50,13 @@ nextflow_process {
     script "main.nf"
     process "my_process"
     config "path/to/test/nextflow.config"
-
+    autoSort false
     ...
 
 }
 ```
 
-It is also possible to overwrite the `config` property for a specific test:
+It is also possible to overwrite the `config` or `autoSort` property for a specific test:
 
 ```
 nextflow_process {
@@ -63,6 +64,7 @@ nextflow_process {
    test("my test") {
 
       config "path/to/test/nextflow.config"
+      autoSort false
       ...
 
     }

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -16,6 +16,7 @@ import com.askimed.nf.test.core.GroupTestExecutionListener;
 import com.askimed.nf.test.core.TestExecutionEngine;
 import com.askimed.nf.test.core.reports.TapTestReportWriter;
 import com.askimed.nf.test.core.reports.XmlReportWriter;
+import com.askimed.nf.test.lang.TestSuiteBuilder;
 import com.askimed.nf.test.plugins.PluginManager;
 import com.askimed.nf.test.util.AnsiColors;
 
@@ -47,7 +48,7 @@ public class RunTestsCommand implements Callable<Integer> {
 	private String tap = null;
 
 	@Option(names = {
-		"--junitxml" }, description = "Write test results in Junit Xml Format", required = false, showDefaultValue = Visibility.ALWAYS)
+			"--junitxml" }, description = "Write test results in Junit Xml Format", required = false, showDefaultValue = Visibility.ALWAYS)
 	private String junitXml = null;
 
 	@Option(names = { "--update-snapshot",
@@ -95,7 +96,10 @@ public class RunTestsCommand implements Callable<Integer> {
 						System.out.println("Found " + scripts.size() + " files in test directory.");
 					}
 
+					TestSuiteBuilder.setConfig(config);
+
 				} else {
+					TestSuiteBuilder.setConfig(null);
 					System.out.println(AnsiColors.yellow("Warning: This pipeline has no nf-test config file."));
 				}
 

--- a/src/main/java/com/askimed/nf/test/config/Config.java
+++ b/src/main/java/com/askimed/nf/test/config/Config.java
@@ -26,6 +26,8 @@ public class Config {
 
 	private boolean withTrace = true;
 
+	private boolean autoSort = true;
+
 	private PluginManager pluginManager = new PluginManager(PluginManager.FORCE_UPDATE);
 
 	private String configFile = DEFAULT_NEXTFLOW_CONFIG;
@@ -62,12 +64,24 @@ public class Config {
 		}
 	}
 
+	public void wthTrace(boolean withTrace) {
+		this.withTrace = withTrace;
+	}
+	
 	public void setWithTrace(boolean withTrace) {
 		this.withTrace = withTrace;
 	}
 
 	public boolean isWithTrace() {
 		return withTrace;
+	}
+
+	public void autoSort(boolean autoSort) {
+		this.autoSort = autoSort;
+	}
+
+	public boolean isAutoSort() {
+		return autoSort;
 	}
 
 	public void libDir(String libDir) {

--- a/src/main/java/com/askimed/nf/test/config/Config.java
+++ b/src/main/java/com/askimed/nf/test/config/Config.java
@@ -64,16 +64,20 @@ public class Config {
 		}
 	}
 
-	public void wthTrace(boolean withTrace) {
+	public void withTrace(boolean withTrace) {
 		this.withTrace = withTrace;
 	}
-	
+
 	public void setWithTrace(boolean withTrace) {
 		this.withTrace = withTrace;
 	}
 
 	public boolean isWithTrace() {
 		return withTrace;
+	}
+
+	public void setAutoSort(boolean autoSort) {
+		this.autoSort = autoSort;
 	}
 
 	public void autoSort(boolean autoSort) {

--- a/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.util.List;
 import java.util.Vector;
 
+import com.askimed.nf.test.config.Config;
+
 public abstract class AbstractTestSuite implements ITestSuite {
 
 	private String name;
@@ -17,6 +19,13 @@ public abstract class AbstractTestSuite implements ITestSuite {
 	private List<ITest> tests = new Vector<ITest>();
 
 	private String filename;
+
+	private boolean autoSort = true;
+
+	@Override
+	public void configure(Config config) {
+		autoSort = config.isAutoSort();
+	}
 
 	public void name(String name) {
 		this.name = name;
@@ -45,6 +54,15 @@ public abstract class AbstractTestSuite implements ITestSuite {
 	public String getProfile() {
 		return profile;
 	}
+
+	public void autoSort(boolean autoSort) {
+		this.autoSort = autoSort;
+	}
+	
+	public boolean isAutoSort() {
+		return autoSort;
+	}
+	
 
 	@Override
 	public void setGlobalConfigFile(File globalConfig) {

--- a/src/main/java/com/askimed/nf/test/core/ITestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/ITestSuite.java
@@ -3,18 +3,22 @@ package com.askimed.nf.test.core;
 import java.io.File;
 import java.util.List;
 
+import com.askimed.nf.test.config.Config;
+
 public interface ITestSuite {
 
 	public List<ITest> getTests();
 
 	public String getName();
-	
+
 	public void setProfile(String profile);
-	
+
 	public void setGlobalConfigFile(File config);
 
 	public void setFilename(String filename);
-	
+
 	public String getFilename();
-	
+
+	public void configure(Config config);
+
 }

--- a/src/main/java/com/askimed/nf/test/lang/TestSuiteBuilder.java
+++ b/src/main/java/com/askimed/nf/test/lang/TestSuiteBuilder.java
@@ -5,6 +5,7 @@ import java.io.File;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
 
+import com.askimed.nf.test.config.Config;
 import com.askimed.nf.test.core.ITestSuite;
 import com.askimed.nf.test.lang.function.FunctionTestSuite;
 import com.askimed.nf.test.lang.pipeline.PipelineTestSuite;
@@ -18,56 +19,58 @@ import groovy.lang.GroovyShell;
 
 public class TestSuiteBuilder {
 
-	static ITestSuite nextflow_pipeline(
-			@DelegatesTo(value = PipelineTestSuite.class, strategy = Closure.DELEGATE_ONLY) final Closure closure) {
+	private static Config config = null;
 
-		final PipelineTestSuite suite = new PipelineTestSuite();
+	public static void setConfig(Config config) {
+		TestSuiteBuilder.config = config;
+	}
 
-		closure.setDelegate(suite);
-		closure.setResolveStrategy(Closure.DELEGATE_ONLY);
-		closure.call();
+	public static ITestSuite nextflow_pipeline(final Closure closure) {
+
+		PipelineTestSuite suite = new PipelineTestSuite();
+		executeClosure(suite, closure);
 
 		return suite;
 
 	}
 
-	static ITestSuite nextflow_workflow(
-			@DelegatesTo(value = PipelineTestSuite.class, strategy = Closure.DELEGATE_ONLY) final Closure closure) {
+	public static ITestSuite nextflow_workflow(Closure closure) {
 
-		final WorkflowTestSuite suite = new WorkflowTestSuite();
-
-		closure.setDelegate(suite);
-		closure.setResolveStrategy(Closure.DELEGATE_ONLY);
-		closure.call();
+		WorkflowTestSuite suite = new WorkflowTestSuite();
+		executeClosure(suite, closure);
 
 		return suite;
 
 	}
 
-	static ITestSuite nextflow_process(
-			@DelegatesTo(value = PipelineTestSuite.class, strategy = Closure.DELEGATE_ONLY) final Closure closure) {
+	public static ITestSuite nextflow_process(Closure closure) {
 
-		final ProcessTestSuite suite = new ProcessTestSuite();
-
-		closure.setDelegate(suite);
-		closure.setResolveStrategy(Closure.DELEGATE_ONLY);
-		closure.call();
+		ProcessTestSuite suite = new ProcessTestSuite();
+		executeClosure(suite, closure);
 
 		return suite;
 
 	}
 
-	static ITestSuite nextflow_function(
+	public static ITestSuite nextflow_function(
 			@DelegatesTo(value = PipelineTestSuite.class, strategy = Closure.DELEGATE_ONLY) final Closure closure) {
 
-		final FunctionTestSuite suite = new FunctionTestSuite();
+		FunctionTestSuite suite = new FunctionTestSuite();
+
+		executeClosure(suite, closure);
+
+		return suite;
+
+	}
+
+	private static void executeClosure(ITestSuite suite, Closure closure) {
+		if (config != null) {
+			suite.configure(config);
+		}
 
 		closure.setDelegate(suite);
 		closure.setResolveStrategy(Closure.DELEGATE_ONLY);
 		closure.call();
-
-		return suite;
-
 	}
 
 	public static ITestSuite parse(File script) throws Exception {

--- a/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
@@ -45,6 +45,7 @@ public class ProcessTest extends AbstractTest {
 	public ProcessTest(ProcessTestSuite parent) {
 		super();
 		this.parent = parent;
+		this.autoSort = parent.isAutoSort();
 		context = new TestContext(this);
 		context.setName(parent.getProcess());
 	}

--- a/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTest.java
@@ -48,7 +48,7 @@ public class WorkflowTest extends AbstractTest {
 	public WorkflowTest(WorkflowTestSuite parent) {
 		super();
 		this.parent = parent;
-
+		this.autoSort = parent.isAutoSort();
 		context = new TestContext(this);
 		context.setName(parent.getWorkflow());
 	}
@@ -86,7 +86,7 @@ public class WorkflowTest extends AbstractTest {
 	public void when(@DelegatesTo(value = WorkflowTest.class, strategy = Closure.DELEGATE_ONLY) final Closure closure) {
 		when = new TestCode(closure);
 	}
-	
+
 	public void expect(
 			@DelegatesTo(value = PipelineTest.class, strategy = Closure.DELEGATE_ONLY) final Closure closure) {
 		then = new TestCode(closure);
@@ -115,11 +115,11 @@ public class WorkflowTest extends AbstractTest {
 		}
 
 		context.init(baseDir, outputDir.getAbsolutePath());
-		
+
 		if (setup != null) {
 			setup.execute(context);
 		}
-		
+
 		if (when != null) {
 			when.execute(context);
 		}

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -27,7 +27,6 @@ public class ProcessTest {
 	@BeforeEach
 	public void setUp() throws IOException {
 		FileUtil.deleteDirectory(new File(".nf-test"));
-		System.out.println("Deleted: " +  new File("nf-test.config").delete());
 	}
 
 	@Test

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -27,6 +27,7 @@ public class ProcessTest {
 	@BeforeEach
 	public void setUp() throws IOException {
 		FileUtil.deleteDirectory(new File(".nf-test"));
+		new File("nf-test.config").delete();
 	}
 
 	@Test

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -4,26 +4,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.askimed.nf.test.App;
+import com.askimed.nf.test.util.AnsiColors;
+import com.askimed.nf.test.util.AnsiText;
 import com.askimed.nf.test.util.FileUtil;
 
 public class ProcessTest {
 
 	static {
 
-		// AnsiColors.disable();
-		// AnsiText.disable();
+		 AnsiColors.disable();
+		 AnsiText.disable();
 
 	}
 
-	@BeforeAll
-	public static void setUp() throws IOException {
+	@BeforeEach
+	public void setUp() throws IOException {
 		FileUtil.deleteDirectory(new File(".nf-test"));
-		new File("nf-test.config").delete();
+		System.out.println("Deleted: " +  new File("nf-test.config").delete());
 	}
 
 	@Test
@@ -31,6 +35,37 @@ public class ProcessTest {
 
 		App app = new App();
 		int exitCode = app.run(new String[] { "test", "test-data/process/default/test_process_success.nf.test" });
+		assertEquals(0, exitCode);
+
+	}
+
+	@Test
+	public void testDisableAutoSortConfig() throws Exception {
+
+		Files.copy(Paths.get("test-data", "autosort.nf.test"), Paths.get("nf-test.config"));
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/autosort/test_process.nf.test" });
+		// Fails, because expects sorted channels
+		assertEquals(1, exitCode);
+
+	}
+	
+	@Test
+	public void testDisableAutoSortTestSuite() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/autosort/test_process_autosort.nf.test" });
+		// Fails, because expects sorted channels
+		assertEquals(1, exitCode);
+
+	}
+	
+	@Test
+	public void testDisableAutoSortTestSuiteAndOverwrite() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/autosort/test_process_autosort2.nf.test" });
 		assertEquals(0, exitCode);
 
 	}
@@ -116,8 +151,7 @@ public class ProcessTest {
 		assertEquals(0, exitCode);
 
 	}
-	
-	
+
 	@Test
 	public void testNestedParams() throws Exception {
 
@@ -126,5 +160,5 @@ public class ProcessTest {
 		assertEquals(0, exitCode);
 
 	}
-	
+
 }

--- a/test-data/autosort.nf.test
+++ b/test-data/autosort.nf.test
@@ -1,0 +1,7 @@
+config {
+
+	configFile ""
+
+	autoSort false
+
+}

--- a/test-data/process/autosort/test_process.nf
+++ b/test-data/process/autosort/test_process.nf
@@ -1,0 +1,18 @@
+process TEST_PROCESS {
+
+  publishDir "${params.outdir}", mode: 'copy'
+
+  input:
+    val number
+    val name
+
+  output:
+     path "*.txt", emit: my_output_files
+     tuple val(number), val(name), path("*.txt"), emit: my_output_tuple
+     val number, emit: my_output_numbers
+
+  """
+  echo "lukas forer" > "${number}_${name}.txt"
+  """
+
+}

--- a/test-data/process/autosort/test_process.nf.test
+++ b/test-data/process/autosort/test_process.nf.test
@@ -1,0 +1,40 @@
+nextflow_process {
+
+  name "Test process xy"
+
+  script "test-data/process/autosort/test_process.nf"
+  process "TEST_PROCESS"
+
+  test("Should create 5 files") {
+
+    when {
+      params {
+        outdir = "$outputDir/seb7"
+      }
+      process {
+        """
+        input[0] = Channel.of(1..5)
+        input[1] = "test"
+        """
+      }
+    }
+
+    then {
+      assert process.success
+      assert process.out.my_output_numbers == [1,2,3,4,5]      
+      
+      assert process.out.my_output_files
+      assert process.out.my_output_files.size() == 5
+      def file1 = path process.out.my_output_files.get(0)
+      assert file1.fileName.toString() == "1_test.txt"
+      assert file1.fileName.toString().endsWith("test.txt")
+      assert file1.readLines() == ['lukas forer']
+
+      assert process.out.my_output_tuple
+      assert process.out.my_output_tuple.size() == 5
+      assert process.out.my_output_tuple.get(0).size() == 3
+    }
+
+  }
+
+}

--- a/test-data/process/autosort/test_process_autosort.nf.test
+++ b/test-data/process/autosort/test_process_autosort.nf.test
@@ -1,0 +1,42 @@
+nextflow_process {
+
+  name "Test process xy"
+
+  script "test-data/process/autosort/test_process.nf"
+  process "TEST_PROCESS"
+  
+  autoSort false
+
+  test("Should create 5 files") {
+
+    when {
+      params {
+        outdir = "$outputDir/seb7"
+      }
+      process {
+        """
+        input[0] = Channel.of(1..5)
+        input[1] = "test"
+        """
+      }
+    }
+
+    then {
+      assert process.success
+      assert process.out.my_output_numbers == [1,2,3,4,5]      
+      
+      assert process.out.my_output_files
+      assert process.out.my_output_files.size() == 5
+      def file1 = path process.out.my_output_files.get(0)
+      assert file1.fileName.toString() == "1_test.txt"
+      assert file1.fileName.toString().endsWith("test.txt")
+      assert file1.readLines() == ['lukas forer']
+
+      assert process.out.my_output_tuple
+      assert process.out.my_output_tuple.size() == 5
+      assert process.out.my_output_tuple.get(0).size() == 3
+    }
+
+  }
+
+}

--- a/test-data/process/autosort/test_process_autosort2.nf.test
+++ b/test-data/process/autosort/test_process_autosort2.nf.test
@@ -1,0 +1,44 @@
+nextflow_process {
+
+  name "Test process xy"
+
+  script "test-data/process/default/test_process.nf"
+  process "TEST_PROCESS"
+
+  autoSort false
+
+  test("Should create 5 files") {
+
+    autoSort true
+
+    when {
+      params {
+        outdir = "$outputDir/seb7"
+      }
+      process {
+        """
+        input[0] = Channel.of(1..5)
+        input[1] = "test"
+        """
+      }
+    }
+
+    then {
+      assert process.success
+      assert process.out.my_output_numbers == [1,2,3,4,5]      
+      
+      assert process.out.my_output_files
+      assert process.out.my_output_files.size() == 5
+      def file1 = path process.out.my_output_files.get(0)
+      assert file1.fileName.toString() == "1_test.txt"
+      assert file1.fileName.toString().endsWith("test.txt")
+      assert file1.readLines() == ['lukas forer']
+
+      assert process.out.my_output_tuple
+      assert process.out.my_output_tuple.size() == 5
+      assert process.out.my_output_tuple.get(0).size() == 3
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR adds the possibility to disable sorted channels. Thus, no warning message appears if a channel contains objects like `Maps`. In combination with #61 we should able to fix #36.

It is possible to disable sorted channels on different levels:

In `nf-test.config`:

```
config {

	autoSort false

}
```

For a testsuite:

```
nextflow_process {
  
  autoSort false

}
```

Or for a test:

```
test("Should create 5 files") {

  autoSort true

}
```
