### PR TITLE
small code typo in the GZip files example (i think)

### DIFF
--- a/docs/assertions/files.md
+++ b/docs/assertions/files.md
@@ -38,6 +38,6 @@ nf-test extends `path` by a `linesGzip` property that can be used to read gzip c
 
 
 ```Groovy
-assert path(process.out.out_ch.get(0)).linesGzip.size == 5
+assert path(process.out.out_ch.get(0)).linesGzip.size() == 5
 assert path(process.out.out_ch.get(0)).linesGzip.contains("Line Content")
 ```


### PR DESCRIPTION
this is the only way this worked for me, so i think maybe adding the parentheses to the size method(?) are needed, but i'm new to this language though so i apologize if not!