### PR TITLE
Add `options` keyword to set specific Nextflow options

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 ## Setup test profile
 
-To run your test using a specific Netxflow profile, you can use the `--profile` argument on the command line or define a default profile in `nf-test.config`.
+To run your test using a specific Nextflow profile, you can use the `--profile` argument on the command line or define a default profile in `nf-test.config`.
 
 
 ##  `nf-test.config`
@@ -25,6 +25,8 @@ config {
     withTrace false
     //disable sorted channels
     autoSort false
+    // add Nextflow options
+    options "-dump-channels -stub-run"
 }
 ```
 
@@ -51,12 +53,13 @@ nextflow_process {
     process "my_process"
     config "path/to/test/nextflow.config"
     autoSort false
+    options "-dump-channels"
     ...
 
 }
 ```
 
-It is also possible to overwrite the `config` or `autoSort` property for a specific test:
+It is also possible to overwrite the `config`, `autoSort` or Nextflow properties (e.g. `options "-dump-channels"`) for a specific test. Depending on the used Nextflow option, also add the `--debug` nf-test option on the command-line to see the addtional output.  
 
 ```
 nextflow_process {
@@ -65,6 +68,7 @@ nextflow_process {
 
       config "path/to/test/nextflow.config"
       autoSort false
+      options "-dump-channels"
       ...
 
     }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -194,6 +194,17 @@ In this case, the `docker` profile defined in the Nextflow pipeline is used to e
 
 Congratulations! You created you first nf-test specification.
 
+### Nextflow options
+nf-test also allows to specify Nextflow options (e.g. `-dump-channels`, `-stub-run`) globally in the nf-test.config file or by adding an option to the test suite or the actual test. Read more about this in the [configuration](configuration.md) documentation. 
+
+
+```
+nextflow_process {
+  
+	options "-dump-channels"
+
+}
+```
 
 ## What's next?
 

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -14,6 +14,7 @@ import java.util.function.Consumer;
 import com.askimed.nf.test.config.Config;
 import com.askimed.nf.test.core.AnsiTestExecutionListener;
 import com.askimed.nf.test.core.GroupTestExecutionListener;
+import com.askimed.nf.test.core.TagQuery;
 import com.askimed.nf.test.core.TestExecutionEngine;
 import com.askimed.nf.test.core.reports.TapTestReportWriter;
 import com.askimed.nf.test.core.reports.XmlReportWriter;
@@ -62,6 +63,10 @@ public class RunTestsCommand implements Callable<Integer> {
 	@Option(names = {
 			"--plugins" }, description = "Library extension path", required = false, showDefaultValue = Visibility.ALWAYS)
 	private String plugins = null;
+
+	@Option(names = {
+			"--tag" }, description = "Execute only tests with this tag", required = false, showDefaultValue = Visibility.ALWAYS)
+	private List<String> tags = new Vector<String>();
 
 	@Override
 	public Integer call() throws Exception {
@@ -117,7 +122,8 @@ public class RunTestsCommand implements Callable<Integer> {
 			}
 
 			if (scripts.size() == 0) {
-				System.out.println(AnsiColors.red("Error: No tests or test directories containing scripts that end with *.test provided."));
+				System.out.println(AnsiColors
+						.red("Error: No tests or test directories containing scripts that end with *.test provided."));
 				return 2;
 			}
 
@@ -133,9 +139,13 @@ public class RunTestsCommand implements Callable<Integer> {
 				listener.addListener(new XmlReportWriter(junitXml));
 			}
 
+			TagQuery tagQuery = new TagQuery(tags);
+			System.out.println(tagQuery);
+
 			TestExecutionEngine engine = new TestExecutionEngine();
 			engine.setListener(listener);
 			engine.setScripts(scripts);
+			engine.setTagQuery(tagQuery);
 			engine.setDebug(debug);
 			engine.setWorkDir(workDir);
 			engine.setUpdateSnapshot(updateSnapshot);
@@ -217,11 +227,12 @@ public class RunTestsCommand implements Callable<Integer> {
 		for (File path : paths) {
 			if (path.isDirectory()) {
 				scripts.addAll(findTests(path));
-			}
-			else {
+			} else {
 				scripts.add(path);
-			};
-		};
+			}
+			;
+		}
+		;
 		return scripts;
 	}
 }

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -140,7 +140,6 @@ public class RunTestsCommand implements Callable<Integer> {
 			}
 
 			TagQuery tagQuery = new TagQuery(tags);
-			System.out.println(tagQuery);
 
 			TestExecutionEngine engine = new TestExecutionEngine();
 			engine.setListener(listener);

--- a/src/main/java/com/askimed/nf/test/config/Config.java
+++ b/src/main/java/com/askimed/nf/test/config/Config.java
@@ -28,6 +28,8 @@ public class Config {
 
 	private boolean autoSort = true;
 
+	private String options = "";
+
 	private PluginManager pluginManager = new PluginManager(PluginManager.FORCE_UPDATE);
 
 	private String configFile = DEFAULT_NEXTFLOW_CONFIG;
@@ -86,6 +88,18 @@ public class Config {
 
 	public boolean isAutoSort() {
 		return autoSort;
+	}
+
+	public void setOptions(String options) {
+		this.options = options;
+	}
+
+	public void options(String options) {
+		this.options = options;
+	}
+
+	public String getOptions() {
+		return options;
 	}
 
 	public void libDir(String libDir) {

--- a/src/main/java/com/askimed/nf/test/core/AbstractTest.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTest.java
@@ -38,9 +38,12 @@ public abstract class AbstractTest implements ITest {
 	private List<String> tags = new Vector<String>();
 
 	private AbstractTestSuite parent;
-	
+
+	private String options;
+
 	public AbstractTest(AbstractTestSuite parent) {
 		this.parent = parent;
+		options = parent.getOptions();
 	}
 
 	public void config(String config) {
@@ -158,11 +161,19 @@ public abstract class AbstractTest implements ITest {
 		return tags;
 	}
 
+	public void options(String options) {
+		this.options = options;
+	}
+
+	public String getOptions() {
+		return options;
+	}
+
 	@Override
 	public AbstractTestSuite getParent() {
 		return parent;
 	}
-	
+
 	@Override
 	public void skip() {
 		skipped = true;

--- a/src/main/java/com/askimed/nf/test/core/AbstractTest.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTest.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Vector;
 
 import com.askimed.nf.test.config.Config;
 import com.askimed.nf.test.util.FileUtil;
@@ -32,9 +34,13 @@ public abstract class AbstractTest implements ITest {
 	private boolean debug = false;
 
 	private boolean withTrace = true;
-	
-	public AbstractTest() {
 
+	private List<String> tags = new Vector<String>();
+
+	private AbstractTestSuite parent;
+	
+	public AbstractTest(AbstractTestSuite parent) {
+		this.parent = parent;
 	}
 
 	public void config(String config) {
@@ -44,7 +50,7 @@ public abstract class AbstractTest implements ITest {
 	public File getConfig() {
 		return config;
 	}
-	
+
 	protected String getWorkDir() {
 
 		File workDir = new File("nf-test");
@@ -143,6 +149,20 @@ public abstract class AbstractTest implements ITest {
 		}
 	}
 
+	public void tag(String tag) {
+		tags.add(tag);
+	}
+
+	@Override
+	public List<String> getTags() {
+		return tags;
+	}
+
+	@Override
+	public AbstractTestSuite getParent() {
+		return parent;
+	}
+	
 	@Override
 	public void skip() {
 		skipped = true;
@@ -156,10 +176,10 @@ public abstract class AbstractTest implements ITest {
 	public void setTestSuite(ITestSuite suite) {
 		this.suite = suite;
 	}
-	
+
 	@Override
 	public ITestSuite getTestSuite() {
-		return suite;		
+		return suite;
 	}
 
 	public void debug(boolean debug) {
@@ -174,16 +194,16 @@ public abstract class AbstractTest implements ITest {
 	public boolean isDebug() {
 		return debug;
 	}
-	
+
 	@Override
 	public void setWithTrace(boolean withTrace) {
 		this.withTrace = withTrace;
 	}
-	
+
 	public boolean isWithTrace() {
 		return withTrace;
 	}
-	
+
 	protected void shareDirectories(String[] directories, String metaDir) throws IOException {
 		for (String directory : directories) {
 			File localDirectory = new File(directory);
@@ -194,14 +214,13 @@ public abstract class AbstractTest implements ITest {
 		}
 	}
 
-	
 	@Override
 	public void setUpdateSnapshot(boolean updateSnapshot) {
 		this.updateSnapshot = updateSnapshot;
 	}
-	
+
 	public boolean isUpdateSnapshot() {
 		return updateSnapshot;
 	}
-	
+
 }

--- a/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
@@ -22,6 +22,8 @@ public abstract class AbstractTestSuite implements ITestSuite {
 
 	private boolean autoSort = true;
 
+	private List<String> tags = new Vector<String>();
+
 	@Override
 	public void configure(Config config) {
 		autoSort = config.isAutoSort();
@@ -58,11 +60,10 @@ public abstract class AbstractTestSuite implements ITestSuite {
 	public void autoSort(boolean autoSort) {
 		this.autoSort = autoSort;
 	}
-	
+
 	public boolean isAutoSort() {
 		return autoSort;
 	}
-	
 
 	@Override
 	public void setGlobalConfigFile(File globalConfig) {
@@ -99,6 +100,20 @@ public abstract class AbstractTestSuite implements ITestSuite {
 	protected void addTest(ITest test) {
 		tests.add(test);
 		test.setTestSuite(this);
+	}
+
+	public void tag(String tag) {
+		tags.add(tag);
+	}
+
+	@Override
+	public List<String> getTags() {
+		return tags;
+	}
+
+	@Override
+	public ITaggable getParent() {
+		return null;
 	}
 
 }

--- a/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
@@ -22,11 +22,14 @@ public abstract class AbstractTestSuite implements ITestSuite {
 
 	private boolean autoSort = true;
 
+	private String options = "";
+
 	private List<String> tags = new Vector<String>();
 
 	@Override
 	public void configure(Config config) {
 		autoSort = config.isAutoSort();
+		options = config.getOptions();
 	}
 
 	public void name(String name) {
@@ -63,6 +66,14 @@ public abstract class AbstractTestSuite implements ITestSuite {
 
 	public boolean isAutoSort() {
 		return autoSort;
+	}
+
+	public void options(String options) {
+		this.options = options;
+	}
+
+	public String getOptions() {
+		return options;
 	}
 
 	@Override

--- a/src/main/java/com/askimed/nf/test/core/ITaggable.java
+++ b/src/main/java/com/askimed/nf/test/core/ITaggable.java
@@ -1,0 +1,13 @@
+package com.askimed.nf.test.core;
+
+import java.util.List;
+
+public interface ITaggable {
+
+	public String getName();
+	
+	public List<String> getTags();
+	
+	public ITaggable getParent();
+
+}

--- a/src/main/java/com/askimed/nf/test/core/ITest.java
+++ b/src/main/java/com/askimed/nf/test/core/ITest.java
@@ -2,7 +2,7 @@ package com.askimed.nf.test.core;
 
 import java.io.File;
 
-public interface ITest {
+public interface ITest extends ITaggable {
 
 	public void setup(File baseDir) throws Throwable;
 
@@ -21,15 +21,15 @@ public interface ITest {
 	public void setDebug(boolean debug);
 
 	public String getHash();
-	
+
 	public void setTestSuite(ITestSuite suite);
-	
+
 	public ITestSuite getTestSuite();
 
 	public void setWithTrace(boolean withTrace);
-	
+
 	public void setUpdateSnapshot(boolean updateSnapshot);
-	
+
 	public boolean isUpdateSnapshot();
 
 }

--- a/src/main/java/com/askimed/nf/test/core/ITestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/ITestSuite.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.askimed.nf.test.config.Config;
 
-public interface ITestSuite {
+public interface ITestSuite extends ITaggable {
 
 	public List<ITest> getTests();
 

--- a/src/main/java/com/askimed/nf/test/core/TagQuery.java
+++ b/src/main/java/com/askimed/nf/test/core/TagQuery.java
@@ -1,0 +1,59 @@
+package com.askimed.nf.test.core;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+
+public class TagQuery {
+
+	private List<String> tags = new Vector<String>();
+
+	public TagQuery() {
+
+	}
+
+	public TagQuery(String... tags) {
+		this.tags = toLowerCase(Arrays.asList(tags));
+	}
+
+	public TagQuery(List<String> tags) {
+		this.tags = toLowerCase(tags);
+	}
+
+	protected List<String> toLowerCase(List<String> tags) {
+		List<String> result = new Vector<String>();
+		for (String tag : tags) {
+			result.add(tag.toLowerCase());
+		}
+		return result;
+	}
+
+	public boolean matches(ITaggable taggable) {
+
+		if (tags == null || tags.size() == 0) {
+			return true;
+		}
+
+		if (tags.contains(taggable.getName().toLowerCase())) {
+			return true;
+		}
+
+		for (String tag : taggable.getTags()) {
+			if (tags.contains(tag.toLowerCase())) {
+				return true;
+			}
+		}
+
+		if (taggable.getParent() != null) {
+			return matches(taggable.getParent());
+		}
+
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return tags.toString();
+	}
+
+}

--- a/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
+++ b/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
@@ -27,12 +27,14 @@ public class TestExecutionEngine {
 	private File baseDir = new File(System.getProperty("user.dir"));
 
 	private boolean withTrace = true;
-	
+
 	private boolean updateSnapshot = false;
 
 	private String libDir = "";
-	
+
 	private PluginManager pluginManager = null;
+
+	private TagQuery tagQuery = new TagQuery();
 
 	public void setScripts(List<File> scripts) {
 		this.scripts = scripts;
@@ -67,7 +69,11 @@ public class TestExecutionEngine {
 		}
 		this.updateSnapshot = updateSnapshot;
 	}
-	
+
+	public void setTagQuery(TagQuery tagQuery) {
+		this.tagQuery = tagQuery;
+	}
+
 	public void setLibDir(String libDir) {
 		this.libDir = libDir;
 	}
@@ -75,12 +81,12 @@ public class TestExecutionEngine {
 	public void setListener(ITestExecutionListener listener) {
 		this.listener = listener;
 	}
-	
+
 	public void setPluginManager(PluginManager pluginManager) {
 		this.pluginManager = pluginManager;
 	}
 
-	protected List<ITestSuite> parse() throws Exception {
+	protected List<ITestSuite> parse(TagQuery tagQuery) throws Exception {
 
 		List<ITestSuite> testSuits = new Vector<ITestSuite>();
 
@@ -95,13 +101,19 @@ public class TestExecutionEngine {
 				throw new Exception("Test file '" + script.getAbsolutePath() + "' not found.");
 			}
 			ITestSuite testSuite = TestSuiteBuilder.parse(script, libDir, pluginManager);
-			if (testId != null) {
-				for (ITest test : testSuite.getTests()) {
+
+			for (ITest test : testSuite.getTests()) {
+				if (testId != null) {
 					if (!test.getHash().startsWith(testId)) {
 						test.skip();
 					}
 				}
+
+				if (!tagQuery.matches(test)) {
+					test.skip();
+				}
 			}
+
 			testSuits.add(testSuite);
 		}
 
@@ -120,7 +132,7 @@ public class TestExecutionEngine {
 			}
 		}
 
-		List<ITestSuite> testSuits = parse();
+		List<ITestSuite> testSuits = parse(tagQuery);
 
 		if (testSuits.size() == 0) {
 			System.out.println(AnsiColors.red("Error: no valid tests found."));
@@ -204,7 +216,7 @@ public class TestExecutionEngine {
 			}
 		}
 
-		List<ITestSuite> testSuits = parse();
+		List<ITestSuite> testSuits = parse(tagQuery);
 
 		if (testSuits.size() == 0) {
 			System.out.println(AnsiColors.red("Error: no valid tests found."));

--- a/src/main/java/com/askimed/nf/test/lang/function/FunctionTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/function/FunctionTest.java
@@ -136,7 +136,7 @@ public class FunctionTest extends AbstractTest {
 		nextflow.setLog(logFile);
 		nextflow.setWork(workDir);
 		nextflow.setParamsFile(paramsFile);
-		nextflow.setOptions(getOptions().split(" "));
+		nextflow.setOptions(getOptions());
 
 		int exitCode = nextflow.execute();
 

--- a/src/main/java/com/askimed/nf/test/lang/function/FunctionTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/function/FunctionTest.java
@@ -34,12 +34,12 @@ public class FunctionTest extends AbstractTest {
 
 	private TestCode then;
 
-	private FunctionTestSuite parent;
-
 	private TestContext context;
 
+	private FunctionTestSuite parent;
+
 	public FunctionTest(FunctionTestSuite parent) {
-		super();
+		super(parent);
 		this.parent = parent;
 		context = new TestContext(this);
 		context.setName(parent.getFunction());

--- a/src/main/java/com/askimed/nf/test/lang/function/FunctionTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/function/FunctionTest.java
@@ -136,6 +136,7 @@ public class FunctionTest extends AbstractTest {
 		nextflow.setLog(logFile);
 		nextflow.setWork(workDir);
 		nextflow.setParamsFile(paramsFile);
+		nextflow.setOptions(getOptions().split(" "));
 
 		int exitCode = nextflow.execute();
 

--- a/src/main/java/com/askimed/nf/test/lang/pipeline/PipelineTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/pipeline/PipelineTest.java
@@ -106,7 +106,7 @@ public class PipelineTest extends AbstractTest {
 		nextflow.setLog(logFile);
 		nextflow.setWork(workDir);
 		nextflow.setParamsFile(paramsFile);
-		nextflow.setOptions(getOptions().split(" "));
+		nextflow.setOptions(getOptions());
 
 		int exitCode = nextflow.execute();
 

--- a/src/main/java/com/askimed/nf/test/lang/pipeline/PipelineTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/pipeline/PipelineTest.java
@@ -27,7 +27,7 @@ public class PipelineTest extends AbstractTest {
 	private TestContext context;
 
 	public PipelineTest(PipelineTestSuite parent) {
-		super();
+		super(parent);
 		this.parent = parent;
 		context = new TestContext(this);
 		context.setName(parent.getName());

--- a/src/main/java/com/askimed/nf/test/lang/pipeline/PipelineTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/pipeline/PipelineTest.java
@@ -106,6 +106,8 @@ public class PipelineTest extends AbstractTest {
 		nextflow.setLog(logFile);
 		nextflow.setWork(workDir);
 		nextflow.setParamsFile(paramsFile);
+		nextflow.setOptions(getOptions().split(" "));
+
 		int exitCode = nextflow.execute();
 
 		context.getWorkflow().loadFromFolder(metaDir);

--- a/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
@@ -133,7 +133,7 @@ public class ProcessTest extends AbstractTest {
 		nextflow.setLog(logFile);
 		nextflow.setWork(workDir);
 		nextflow.setParamsFile(paramsFile);
-		nextflow.setOptions(getOptions().split(" "));
+		nextflow.setOptions(getOptions());
 
 		int exitCode = nextflow.execute();
 

--- a/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
@@ -39,7 +39,7 @@ public class ProcessTest extends AbstractTest {
 	private TestContext context;
 
 	public ProcessTest(ProcessTestSuite parent) {
-		super();
+		super(parent);
 		this.parent = parent;
 		this.autoSort = parent.isAutoSort();
 		context = new TestContext(this);

--- a/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
@@ -133,6 +133,8 @@ public class ProcessTest extends AbstractTest {
 		nextflow.setLog(logFile);
 		nextflow.setWork(workDir);
 		nextflow.setParamsFile(paramsFile);
+		nextflow.setOptions(getOptions().split(" "));
+
 		int exitCode = nextflow.execute();
 
 		// Parse json output

--- a/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTest.java
@@ -145,7 +145,7 @@ public class WorkflowTest extends AbstractTest {
 		nextflow.setLog(logFile);
 		nextflow.setWork(workDir);
 		nextflow.setParamsFile(paramsFile);
-		nextflow.setOptions(getOptions().split(" "));
+		nextflow.setOptions(getOptions());
 
 		int exitCode = nextflow.execute();
 

--- a/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTest.java
@@ -145,6 +145,8 @@ public class WorkflowTest extends AbstractTest {
 		nextflow.setLog(logFile);
 		nextflow.setWork(workDir);
 		nextflow.setParamsFile(paramsFile);
+		nextflow.setOptions(getOptions().split(" "));
+
 		int exitCode = nextflow.execute();
 
 		context.getWorkflow().getOut().loadFromFolder(metaDir, autoSort);

--- a/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTest.java
@@ -42,7 +42,7 @@ public class WorkflowTest extends AbstractTest {
 	private TestContext context;
 
 	public WorkflowTest(WorkflowTestSuite parent) {
-		super();
+		super(parent);
 		this.parent = parent;
 		this.autoSort = parent.isAutoSort();
 		context = new TestContext(this);

--- a/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
+++ b/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
@@ -4,10 +4,11 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.askimed.nf.test.util.BinaryFinder;
 import com.askimed.nf.test.util.Command;
@@ -40,7 +41,7 @@ public class NextflowCommand {
 
 	private Map<String, Object> params;
 
-	private List<String> options = new Vector<String>();
+	private String options = "";
 
 	public static String ERROR = "Nextflow Binary not found. Please check if Nextflow is in a directory accessible by your $PATH variable or set $NEXTFLOW_HOME.";
 
@@ -123,15 +124,11 @@ public class NextflowCommand {
 		return paramsFile;
 	}
 
-	public void setOptions(List<String> options) {
+	public void setOptions(String options) {
 		this.options = options;
 	}
 
-	public void setOptions(String... options) {
-		this.options = Arrays.asList(options);
-	}
-
-	public List<String> getArguments() {
+	public String getOptions() {
 		return options;
 	}
 
@@ -177,7 +174,7 @@ public class NextflowCommand {
 			args.add(work.getAbsolutePath());
 		}
 
-		args.addAll(options);
+		args.addAll(parseOptions(options));
 
 		Command nextflow = new Command(binary);
 		nextflow.setParams(args);
@@ -219,6 +216,15 @@ public class NextflowCommand {
 		writer.write(JsonOutput.toJson(params));
 		writer.close();
 
+	}
+
+	public static List<String> parseOptions(String options) {
+		List<String> list = new Vector<String>();
+		Matcher m = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(options);
+		while (m.find()) {
+			list.add(m.group(1).replace("\"", ""));
+		}
+		return list;
 	}
 
 }

--- a/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
+++ b/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
@@ -4,6 +4,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
@@ -38,6 +39,8 @@ public class NextflowCommand {
 	private File paramsFile;
 
 	private Map<String, Object> params;
+
+	private List<String> options = new Vector<String>();
 
 	public static String ERROR = "Nextflow Binary not found. Please check if Nextflow is in a directory accessible by your $PATH variable or set $NEXTFLOW_HOME.";
 
@@ -120,6 +123,18 @@ public class NextflowCommand {
 		return paramsFile;
 	}
 
+	public void setOptions(List<String> options) {
+		this.options = options;
+	}
+
+	public void setOptions(String... options) {
+		this.options = Arrays.asList(options);
+	}
+
+	public List<String> getArguments() {
+		return options;
+	}
+
 	public int execute() throws IOException {
 
 		if (binary == null) {
@@ -161,6 +176,8 @@ public class NextflowCommand {
 			args.add("-w");
 			args.add(work.getAbsolutePath());
 		}
+
+		args.addAll(options);
 
 		Command nextflow = new Command(binary);
 		nextflow.setParams(args);

--- a/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
+++ b/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
@@ -146,7 +146,6 @@ public class NextflowCommand {
 		writeParamsJson(params, paramsFile);
 
 		List<String> args = new Vector<String>();
-		args.add("-quiet");
 		if (log != null) {
 			args.add("-log");
 			args.add(log.getAbsolutePath());

--- a/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
+++ b/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
@@ -4,6 +4,8 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
@@ -146,6 +148,7 @@ public class NextflowCommand {
 		writeParamsJson(params, paramsFile);
 
 		List<String> args = new Vector<String>();
+		args.add("-quiet");
 		if (log != null) {
 			args.add("-log");
 			args.add(log.getAbsolutePath());
@@ -177,7 +180,7 @@ public class NextflowCommand {
 
 		Command nextflow = new Command(binary);
 		nextflow.setParams(args);
-		nextflow.setSilent(silent);
+		nextflow.setSilent(true);
 		if (out != null) {
 			nextflow.saveStdOut(out.getAbsolutePath());
 		}
@@ -186,10 +189,58 @@ public class NextflowCommand {
 		}
 		if (!silent) {
 			System.out.println();
-			System.out.println("Command: " + nextflow.getExecutedCommand());
+			System.out.println("    Nextflow Command:");
+			System.out.println("      " + nextflow.getExecutedCommand());
 		}
-		return nextflow.execute();
 
+		int result = nextflow.execute();
+
+		if (!silent) {
+			printDebugInfo();
+		}
+		return result;
+
+	}
+
+	protected void printDebugInfo() throws IOException {
+		printStdout();
+		printStderr();
+		printLog();
+	}
+
+	protected void printStdout() throws IOException {
+		if (out != null) {
+			System.out.println();
+			System.out.println("    Stdout:");
+			List<String> lines = Files.readAllLines(out.toPath(), Charset.defaultCharset());
+			for (String line : lines) {
+				System.out.println("      " + line);
+			}
+			System.out.println();
+		}
+	}
+
+	protected void printStderr() throws IOException {
+		if (err != null) {
+			System.out.println("    Stderr:");
+			List<String> lines = Files.readAllLines(err.toPath(), Charset.defaultCharset());
+			;
+			for (String line : lines) {
+				System.out.println("      " + line);
+			}
+			System.out.println();
+		}
+	}
+
+	protected void printLog() throws IOException {
+		if (log != null) {
+			System.out.println("    Nextflow Output:");
+			List<String> lines = NextflowLog.parseLines(log, NextflowLogLevel.INFO);
+			for (String line : lines) {
+				System.out.println("      " + line);
+			}
+			System.out.println();
+		}
 	}
 
 	public int printVersion() throws IOException {

--- a/src/main/java/com/askimed/nf/test/nextflow/NextflowLog.java
+++ b/src/main/java/com/askimed/nf/test/nextflow/NextflowLog.java
@@ -1,0 +1,34 @@
+package com.askimed.nf.test.nextflow;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Vector;
+import java.util.regex.*;
+
+public class NextflowLog {
+
+	public static String PATTERN = "%d{MMM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n";
+
+	public static String logPatternRegex = "^(?<timestamp>(?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d{3})\\s\\[(?<thread>.*?)\\]\\s(?<level>\\S+)\\s(?<logger>.+)\\s+-\\s(?<message>.*)$";
+	public static Pattern pattern = Pattern.compile(logPatternRegex);
+
+	public static List<String> parseLines(File file, NextflowLogLevel level) throws IOException {
+		List<String> lines = Files.readAllLines(file.toPath(), Charset.defaultCharset());
+
+		List<String> parsedLines = new Vector<String>();
+		for (String line : lines) {
+			Matcher matcher = pattern.matcher(line);
+			if (matcher.matches()) {
+				if (matcher.group("level").equals(level.toString())) {
+					parsedLines.add(matcher.group("message"));
+				}
+			}
+		}
+
+		return parsedLines;
+	}
+
+}

--- a/src/main/java/com/askimed/nf/test/nextflow/NextflowLogLevel.java
+++ b/src/main/java/com/askimed/nf/test/nextflow/NextflowLogLevel.java
@@ -1,0 +1,5 @@
+package com.askimed.nf.test.nextflow;
+
+public enum NextflowLogLevel {
+	WARN, INFO, DEBUG
+}

--- a/src/test/java/com/askimed/nf/test/core/TestExecutionEngineTest.java
+++ b/src/test/java/com/askimed/nf/test/core/TestExecutionEngineTest.java
@@ -1,0 +1,123 @@
+package com.askimed.nf.test.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+import java.util.Vector;
+
+import org.junit.jupiter.api.Test;
+
+public class TestExecutionEngineTest {
+
+	@Test
+	public void executeAllTests() throws Exception {
+
+		TagQuery query = new TagQuery();
+		List<String> tests = collectTests(query);
+		assertEquals(3, tests.size());
+		assertTrue(tests.contains("test 1"));
+		assertTrue(tests.contains("test 2"));
+		assertTrue(tests.contains("test 3"));
+
+	}
+
+	@Test
+	public void executeTestByName() throws Exception {
+
+		TagQuery query = new TagQuery("test 1");
+		List<String> tests = collectTests(query);
+		assertEquals(1, tests.size());
+		assertTrue(tests.contains("test 1"));
+
+	}
+
+	@Test
+	public void executeTestSuiteByName() throws Exception {
+		{
+			TagQuery query = new TagQuery("suite 1");
+			List<String> tests = collectTests(query);
+			assertEquals(2, tests.size());
+			assertTrue(tests.contains("test 1"));
+			assertTrue(tests.contains("test 2"));
+		}
+
+		{
+			TagQuery query = new TagQuery("SUITE 1");
+			List<String> tests = collectTests(query);
+			assertEquals(2, tests.size());
+			assertTrue(tests.contains("test 1"));
+			assertTrue(tests.contains("test 2"));
+		}
+	}
+
+	@Test
+	public void executeTestsByTag() throws Exception {
+		{
+			TagQuery query = new TagQuery("tag2");
+			List<String> tests = collectTests(query);
+			assertEquals(1, tests.size());
+			assertTrue(tests.contains("test 1"));
+		}
+		{
+			TagQuery query = new TagQuery("TAG2");
+			List<String> tests = collectTests(query);
+			assertEquals(1, tests.size());
+			assertTrue(tests.contains("test 1"));
+		}
+	}
+
+	@Test
+	public void executeTestsByTagAcrossSuites() throws Exception {
+
+		TagQuery query = new TagQuery("tag5");
+		List<String> tests = collectTests(query);
+		assertEquals(2, tests.size());
+		assertTrue(tests.contains("test 2"));
+		assertTrue(tests.contains("test 3"));
+	}
+
+	@Test
+	public void executeTestsBySuiteTag() throws Exception {
+
+		TagQuery query = new TagQuery("tag1");
+		List<String> tests = collectTests(query);
+		assertEquals(2, tests.size());
+		assertTrue(tests.contains("test 1"));
+		assertTrue(tests.contains("test 2"));
+	}
+
+	@Test
+	public void executeTestsByMultipleTags() throws Exception {
+
+		TagQuery query = new TagQuery("tag3", "tag4");
+		List<String> tests = collectTests(query);
+		assertEquals(2, tests.size());
+		assertTrue(tests.contains("test 1"));
+		assertTrue(tests.contains("test 2"));
+	}
+
+	protected List<String> collectTests(TagQuery query) throws Exception {
+		List<File> scripts = new Vector<File>();
+		scripts.add(new File("test-data/suite1.nf.test"));
+		scripts.add(new File("test-data/suite2.nf.test"));
+		TestExecutionEngine engine = new TestExecutionEngine();
+		engine.setScripts(scripts);
+		List<ITestSuite> testSuits = engine.parse(query);
+		return getCollectedTests(testSuits);
+	}
+
+	protected List<String> getCollectedTests(List<ITestSuite> suites) {
+		List<String> tests = new Vector<String>();
+		for (ITestSuite suite : suites) {
+			for (ITest test : suite.getTests()) {
+				if (!test.isSkipped()) {
+					tests.add(test.getName());
+				}
+			}
+		}
+		return tests;
+	}
+
+}

--- a/src/test/java/com/askimed/nf/test/nextflow/NextflowCommandTest.java
+++ b/src/test/java/com/askimed/nf/test/nextflow/NextflowCommandTest.java
@@ -1,0 +1,24 @@
+package com.askimed.nf.test.nextflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class NextflowCommandTest {
+
+	@Test
+	public void testParseOptions() {
+
+		List<String> options = NextflowCommand.parseOptions("--a --b");
+		assertEquals(2, options.size());
+
+		options = NextflowCommand.parseOptions("--a \"value with space\" --b");
+		assertEquals(3, options.size());
+		assertEquals("--a", options.get(0));
+		assertEquals("value with space", options.get(1));
+		assertEquals("--b", options.get(2));
+	}
+
+}

--- a/test-data/suite1.nf.test
+++ b/test-data/suite1.nf.test
@@ -1,0 +1,21 @@
+nextflow_process {
+
+	name "suite 1"
+	tag "tag1"
+
+
+	test("test 1") {
+	
+		tag "tag2"
+		tag "tag3"	 
+
+	}
+	
+	test("test 2") {
+	
+		tag "tag4"
+		tag "tag5"	 
+
+	}
+
+}

--- a/test-data/suite2.nf.test
+++ b/test-data/suite2.nf.test
@@ -1,0 +1,11 @@
+nextflow_process {
+
+	name "suite 2"
+
+	test("test 3") {
+	
+		tag "tag5"
+
+	}
+	
+}


### PR DESCRIPTION
This PR adds the possibility to set additional nextflow options. This should fix #71 and #73.

It is possible to set and overwrite options on different levels:

In `nf-test.config`:

```
config {

	options "-dump-channels -stub-run"

}
```

For a testsuite:

```
nextflow_process {
  
	options "-dump-channels"

}
```

Or for a test:

```
test("Should create 5 files") {

	options "-dump-channels"

}
```

## Output messages

By default, all Nextflow output (e.g. println, dump-channels)  or error messages  are written to `.nf-test/<work-dir>/meta/std.*`. Set the nf-test `--debug` option, to output everything on the command-line. 


What do you think? @ewels @matthdsm