### PR TITLE
Add basic logging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test_mock.nf
 /.nf-test/
 site
 /tests
+/.nf-test.log

--- a/example/hello.nf.test.snap
+++ b/example/hello.nf.test.snap
@@ -1,0 +1,34 @@
+{
+    "hello world example should start 4 processes": {
+        "content": [
+            {
+                "stderr": [
+                    
+                ],
+                "errorReport": "",
+                "exitStatus": 0,
+                "failed": false,
+                "stdout": [
+                    "WARN: Task runtime metrics are not reported when using macOS without a container engine",
+                    "Hola world!",
+                    "",
+                    "Ciao world!",
+                    "",
+                    "Hello world!",
+                    "",
+                    "Bonjour world!",
+                    ""
+                ],
+                "errorMessage": "",
+                "trace": {
+                    "tasksFailed": 0,
+                    "tasksCount": 4,
+                    "tasksSucceeded": 4
+                },
+                "name": "workflow",
+                "success": true
+            }
+        ],
+        "timestamp": "2023-09-03T11:00:53.244626"
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,26 @@
 			<version>1.3</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-api</artifactId>
+		    <version>2.0.7</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/ch.qos.logback/logback-classic -->
+		<dependency>
+		    <groupId>ch.qos.logback</groupId>
+		    <artifactId>logback-classic</artifactId>
+		    <version>1.4.11</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/ch.qos.logback/logback-core -->
+		<dependency>
+		    <groupId>ch.qos.logback</groupId>
+		    <artifactId>logback-core</artifactId>
+		    <version>1.4.11</version>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/askimed/nf/test/App.java
+++ b/src/main/java/com/askimed/nf/test/App.java
@@ -1,5 +1,10 @@
 package com.askimed.nf.test;
 
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.askimed.nf.test.commands.CleanCommand;
 import com.askimed.nf.test.commands.GenerateTestsCommand;
 import com.askimed.nf.test.commands.InitCommand;
@@ -7,9 +12,9 @@ import com.askimed.nf.test.commands.ListTestsCommand;
 import com.askimed.nf.test.commands.RunTestsCommand;
 import com.askimed.nf.test.commands.UpdatePluginsCommand;
 import com.askimed.nf.test.commands.VersionCommand;
-import com.askimed.nf.test.util.AnsiText;
-import com.askimed.nf.test.util.Emoji;
+import com.askimed.nf.test.util.LoggerUtil;
 
+import ch.qos.logback.classic.Level;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -20,8 +25,23 @@ public class App {
 
 	public static final String VERSION = "0.7.3";
 
+	public static final String PACKAGE =  "com.askimed.nf.test";
+	
+	public static final String LOG_FILENAME = ".nf-test.log";
+
+	public static final Level LOG_LEVEL = Level.DEBUG;
+
+	private static Logger log = LoggerFactory.getLogger(App.class);
+
 	public int run(String[] args) {
 
+		//TODO: move LoggerUtil.init(..) to AbstractCommand to use `--log`and `--log-level`
+		
+		LoggerUtil.init(PACKAGE, LOG_FILENAME, LOG_LEVEL);
+
+		log.info(App.NAME + " " + App.VERSION);
+		log.info("Arguments: " + Arrays.toString(args));
+		
 		CommandLine commandLine = new CommandLine(new App());
 		commandLine.addSubcommand("clean", new CleanCommand());
 		commandLine.addSubcommand("init", new InitCommand());

--- a/src/main/java/com/askimed/nf/test/App.java
+++ b/src/main/java/com/askimed/nf/test/App.java
@@ -1,10 +1,5 @@
 package com.askimed.nf.test;
 
-import java.util.Arrays;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.askimed.nf.test.commands.CleanCommand;
 import com.askimed.nf.test.commands.GenerateTestsCommand;
 import com.askimed.nf.test.commands.InitCommand;
@@ -12,7 +7,6 @@ import com.askimed.nf.test.commands.ListTestsCommand;
 import com.askimed.nf.test.commands.RunTestsCommand;
 import com.askimed.nf.test.commands.UpdatePluginsCommand;
 import com.askimed.nf.test.commands.VersionCommand;
-import com.askimed.nf.test.util.LoggerUtil;
 
 import ch.qos.logback.classic.Level;
 import picocli.CommandLine;
@@ -30,18 +24,13 @@ public class App {
 	public static final String LOG_FILENAME = ".nf-test.log";
 
 	public static final Level LOG_LEVEL = Level.DEBUG;
-
-	private static Logger log = LoggerFactory.getLogger(App.class);
+	
+	public static String[] args;
 
 	public int run(String[] args) {
-
-		//TODO: move LoggerUtil.init(..) to AbstractCommand to use `--log`and `--log-level`
 		
-		LoggerUtil.init(PACKAGE, LOG_FILENAME, LOG_LEVEL);
-
-		log.info(App.NAME + " " + App.VERSION);
-		log.info("Arguments: " + Arrays.toString(args));
-		
+		App.args = args;
+				
 		CommandLine commandLine = new CommandLine(new App());
 		commandLine.addSubcommand("clean", new CleanCommand());
 		commandLine.addSubcommand("init", new InitCommand());

--- a/src/main/java/com/askimed/nf/test/commands/AbstractCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/AbstractCommand.java
@@ -1,10 +1,15 @@
 package com.askimed.nf.test.commands;
 
+import java.util.Arrays;
 import java.util.concurrent.Callable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.askimed.nf.test.App;
 import com.askimed.nf.test.util.AnsiText;
 import com.askimed.nf.test.util.Emoji;
+import com.askimed.nf.test.util.LoggerUtil;
 
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Help.Visibility;
@@ -15,8 +20,19 @@ public abstract class AbstractCommand implements Callable<Integer> {
 			"--silent" }, description = "Hide header and program version", required = false, showDefaultValue = Visibility.ALWAYS)
 	private boolean silent = false;
 
+	@Option(names = {
+			"--log" }, description = "Filename for log file", required = false, showDefaultValue = Visibility.ALWAYS)
+	private String logFilename = App.LOG_FILENAME;
+
+	private static Logger log = LoggerFactory.getLogger(App.class);
+
 	@Override
 	public Integer call() throws Exception {
+
+		LoggerUtil.init(App.PACKAGE, logFilename, App.LOG_LEVEL);
+
+		log.info(App.NAME + " " + App.VERSION);
+		log.info("Arguments: " + Arrays.toString(App.args));
 
 		if (!silent) {
 			printHeader();

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -10,6 +10,10 @@ import java.util.List;
 import java.util.Vector;
 import java.util.function.Consumer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.askimed.nf.test.App;
 import com.askimed.nf.test.config.Config;
 import com.askimed.nf.test.core.AnsiTestExecutionListener;
 import com.askimed.nf.test.core.GroupTestExecutionListener;
@@ -72,6 +76,8 @@ public class RunTestsCommand extends AbstractCommand {
 			"--tag" }, split = ",", description = "Execute only tests with this tag", required = false, showDefaultValue = Visibility.ALWAYS)
 	private List<String> tags = new Vector<String>();
 
+	private static Logger log = LoggerFactory.getLogger(RunTestsCommand.class);
+
 	@Override
 	public Integer execute() throws Exception {
 
@@ -110,6 +116,7 @@ public class RunTestsCommand extends AbstractCommand {
 				} else {
 					TestSuiteBuilder.setConfig(null);
 					System.out.println(AnsiColors.yellow("Warning: This pipeline has no nf-test config file."));
+					log.warn("No nf-test config file found.");
 				}
 
 				scripts = pathsToScripts(testPaths);
@@ -117,6 +124,7 @@ public class RunTestsCommand extends AbstractCommand {
 			} catch (Exception e) {
 
 				System.out.println(AnsiColors.red("Error: Syntax errors in nf-test config file: " + e));
+				log.error("Parsing config file failed", e);
 				if (debug) {
 					e.printStackTrace();
 				}
@@ -127,7 +135,10 @@ public class RunTestsCommand extends AbstractCommand {
 			if (scripts.size() == 0) {
 				System.out.println(AnsiColors
 						.red("Error: No tests or test directories containing scripts that end with *.test provided."));
+				log.error("No tests ot directories found containing test files.");
 				return 2;
+			} else {
+				log.info("Detected {} test files.", scripts.size());
 			}
 
 			loadPlugins(manager, plugins);
@@ -171,6 +182,7 @@ public class RunTestsCommand extends AbstractCommand {
 		} catch (Throwable e) {
 
 			System.out.println(AnsiColors.red("Error: " + e));
+			log.error("Running tests failed.", e);
 
 			if (debug) {
 				e.printStackTrace();

--- a/src/main/java/com/askimed/nf/test/core/AbstractTest.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTest.java
@@ -254,5 +254,10 @@ public abstract class AbstractTest implements ITest {
 	public boolean isUpdateSnapshot() {
 		return updateSnapshot;
 	}
+	
+	@Override
+	public String toString() {
+		return getHash().substring(0, 8) + ": " + getName();
+	}
 
 }

--- a/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
@@ -230,6 +230,11 @@ public abstract class AbstractTestSuite implements ITestSuite {
 	protected boolean isRelative(String path) {
 		return path.startsWith("../") || path.startsWith("./");
 	}
+	
+	@Override
+	public String toString() {
+		return name;
+	}
 
 	class NamedClosure {
 		public String name;

--- a/src/main/java/com/askimed/nf/test/lang/extensions/Snapshot.java
+++ b/src/main/java/com/askimed/nf/test/lang/extensions/Snapshot.java
@@ -2,6 +2,9 @@ package com.askimed.nf.test.lang.extensions;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.askimed.nf.test.core.ITest;
 
 public class Snapshot {
@@ -11,6 +14,8 @@ public class Snapshot {
 	private ITest test;
 
 	private SnapshotFile file;
+
+	private static Logger log = LoggerFactory.getLogger(Snapshot.class);
 
 	public Snapshot(Object actual, ITest test) {
 		this.actual = actual;
@@ -24,23 +29,28 @@ public class Snapshot {
 
 	public boolean match(String id) throws IOException {
 		SnapshotFileItem expected = file.getSnapshot(id);
-		//new snapshot --> create snapshot
+		// new snapshot --> create snapshot
 		if (expected == null) {
+			log.debug("Snapshot '{}' not found.", id);
 			file.createSnapshot(id, actual);
 			file.save();
 			return true;
 		}
 
 		try {
-			//compare actual snapshot with expected
-			return new SnapshotFileItem(actual).equals(expected);
+			// compare actual snapshot with expected
+			boolean match = new SnapshotFileItem(actual).equals(expected);
+			log.debug("Snapshots '{}' match.", id);
+			return match;
 		} catch (Exception e) {
-			// test failes and flag set --> update snapshot
+			// test fails and flag set --> update snapshot
 			if (test.isUpdateSnapshot()) {
+				log.debug("Snapshots '{}' do not match. Update snapshots flag set.", id);
 				file.updateSnapshot(id, actual);
 				file.save();
 				return true;
 			} else {
+				log.debug("Snapshots '{}' do not match.", id);
 				throw e;
 			}
 		}

--- a/src/main/java/com/askimed/nf/test/lang/extensions/SnapshotFile.java
+++ b/src/main/java/com/askimed/nf/test/lang/extensions/SnapshotFile.java
@@ -8,6 +8,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.askimed.nf.test.core.ITestSuite;
 import com.askimed.nf.test.lang.extensions.util.PathConverter;
 
@@ -28,7 +31,9 @@ public class SnapshotFile {
 	private Set<String> updatedSnapshots = new HashSet<String>();
 
 	private boolean removedSnapshots = false;
-	
+
+	private static Logger log = LoggerFactory.getLogger(SnapshotFile.class);
+
 	public static SnapshotFile loadByTestSuite(ITestSuite suite) {
 		String filename = createFilename(suite);
 		return new SnapshotFile(filename);
@@ -46,6 +51,7 @@ public class SnapshotFile {
 		this.filename = filename;
 		File file = new File(filename);
 		if (!file.exists()) {
+			log.debug("Init new snapshot file '{}'", filename);
 			return;
 		}
 		JsonSlurper jsonSlurper = new JsonSlurper();
@@ -57,7 +63,7 @@ public class SnapshotFile {
 			SnapshotFileItem item = new SnapshotFileItem(timestamp, content);
 			snapshots.put(id, item);
 		}
-
+		log.debug("Load snapshots from file '{}'", filename);
 	}
 
 	public SnapshotFileItem getSnapshot(String id) {
@@ -72,11 +78,13 @@ public class SnapshotFile {
 		createdSnapshots.add(id);
 		activeSnapshots.add(id);
 		snapshots.put(id, new SnapshotFileItem(object));
+		log.debug("Created snapshot '{}'", id);
 	}
 
 	public void updateSnapshot(String id, Object object) {
 		updatedSnapshots.add(id);
 		snapshots.put(id, new SnapshotFileItem(object));
+		log.debug("Updated snapshot '{}'", id);
 	}
 
 	public Set<String> getCreatedSnapshots() {
@@ -99,16 +107,17 @@ public class SnapshotFile {
 
 	public void removeObsoleteSnapshots() {
 		removeSnapshots(getObsoleteSnapshots());
-		removedSnapshots = true; 
+		removedSnapshots = true;
 	}
 
 	public boolean hasRemovedSnapsshots() {
 		return removedSnapshots;
 	}
-	
+
 	private void removeSnapshots(Set<String> obsoleteSnapshots) {
 		for (String snapshot : obsoleteSnapshots) {
 			snapshots.remove(snapshot);
+			log.debug("Removed snapshot '{}'", snapshot);
 		}
 	}
 
@@ -121,6 +130,7 @@ public class SnapshotFile {
 		writer = new FileWriter(file);
 		writer.append(prettyJson);
 		writer.close();
+		log.debug("Wrote snapshots to file '{}'", filename);
 	}
 
 	protected static String createFilename(ITestSuite suite) {
@@ -132,6 +142,5 @@ public class SnapshotFile {
 				.addConverter(new PathConverter()).build();
 		return jsonGenerator;
 	}
-
 
 }

--- a/src/main/java/com/askimed/nf/test/util/LoggerUtil.java
+++ b/src/main/java/com/askimed/nf/test/util/LoggerUtil.java
@@ -1,0 +1,43 @@
+package com.askimed.nf.test.util;
+
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.FileAppender;
+
+public class LoggerUtil {
+
+	public static String DEFAULT_PATTERN = "%d{MMM-dd HH:mm:ss.SSS} [%t] %-5level %logger - %msg%n";
+
+	public static void init(String root, String filename, Level level) {
+
+		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+		context.reset();
+
+		Logger logger = context.getLogger(root);
+
+		PatternLayoutEncoder logEncoder = new PatternLayoutEncoder();
+		logEncoder.setContext(context);
+		logEncoder.setPattern(DEFAULT_PATTERN);
+		logEncoder.start();
+
+		FileAppender<ILoggingEvent> appender = new FileAppender<ILoggingEvent>();
+		appender.setEncoder(logEncoder);
+		appender.setContext(context);
+		appender.setFile(filename);
+		appender.setAppend(false);
+		appender.start();
+
+		// TODO: use RollingFileAppender to keep last X log files (like .nextflow.log)
+
+		logger.addAppender(appender);
+		logger.setAdditive(false);
+		logger.setLevel(level);
+
+	}
+
+}


### PR DESCRIPTION
This PR fixes #95 and writes a log file `.nf-test.log` to the current directory. The filename of the log-file can be customised with `--log my-log-file.log`.