### PR TITLE
Enable the execution of dependent modules for generating test data

### DIFF
--- a/docs/docs/testcases/setup.md
+++ b/docs/docs/testcases/setup.md
@@ -1,0 +1,151 @@
+# Setup Method
+
+The setup method allows you to specify processes or workflows that need to be executed before the primary `when` block. It serves as a mechanism to prepare the required input data or set up essential steps prior to the primary processing block.
+
+## Syntax
+
+The setup method is typically used within the context of a test case. The basic syntax for the setup method is as follows:
+
+```groovy
+test("my test"){
+    setup {
+        // Define and execute dependent processes or workflows here
+    }
+}
+```
+
+Within the setup block, you can use the `run` method to define and execute dependent processes or workflows.
+
+The `run` method syntax for a process is as follows:
+
+```groovy
+run("ProcessName") {
+    script "path/to/process/script.nf"
+    process {
+        // Define the process inputs here
+    }
+}
+```
+
+The `run` method syntax for a workflow is as follows:
+
+```groovy
+run("WorkflowName") {
+    script "path/to/workflow/script.nf"
+    workflow {
+        // Define the workflow inputs here
+    }
+}
+```
+
+## Example Usage
+
+### 1. Local Setup Method
+
+In this example, we create a setup method within a Nextflow process definition to execute a dependent process named "ABRICATE_RUN." This process generates input data that is required for the primary process "ABRICATE_SUMMARY." The `setup` block specifies the execution of "ABRICATE_RUN," and the `when` block defines the processing logic for "ABRICATE_SUMMARY."
+
+```groovy
+nextflow_process {
+
+    name "Test process data"
+
+    script "../main.nf"
+    process "ABRICATE_SUMMARY"
+    config "./nextflow.config"
+
+    test("Should use process ABRICATE_RUN to generate input data") {
+
+        setup {
+
+            run("ABRICATE_RUN") {
+                script "../../run/main.nf"
+                process {
+                    """
+                    input[0] =  Channel.fromList([
+                        tuple([ id:'test1', single_end:false ], // meta map
+                            file(params.test_data['bacteroides_fragilis']['genome']['genome_fna_gz'], checkIfExists: true)),
+                        tuple([ id:'test2', single_end:false ],
+                            file(params.test_data['haemophilus_influenzae']['genome']['genome_fna_gz'], checkIfExists: true))
+                    ])
+                    """
+                }
+            }
+
+        }
+
+        when {
+            process {
+                """
+                input[0] = ABRICATE_RUN.out.report.collect{ meta, report -> report }.map{ report -> [[ id: 'test_summary'], report]}
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out).match()
+        }
+    }
+
+}
+```
+
+### 2. Global Setup Method
+
+In this example, a global setup method is defined for all tests within a Nextflow process definition. The setup method is applied to multiple test cases, ensuring consistent setup for each test. This approach is useful when multiple tests share the same setup requirements.
+
+```groovy
+nextflow_process {
+
+    name "Test process data"
+
+    script "../main.nf"
+    process "ABRICATE_SUMMARY"
+    config "./nextflow.config"
+
+    setup {
+        run("ABRICATE_RUN") {
+            script "../../run/main.nf"
+            process {
+                """
+                input[0] =  Channel.fromList([
+                    tuple([ id:'test1', single_end:false ], // meta map
+                        file(params.test_data['bacteroides_fragilis']['genome']['genome_fna_gz'], checkIfExists: true)),
+                    tuple([ id:'test2', single_end:false ],
+                        file(params.test_data['haemophilus_influenzae']['genome']['genome_fna_gz'], checkIfExists: true))
+                ])
+                """
+            }
+        }
+    }
+
+    test("first test") {
+        when {
+            process {
+                """
+                input[0] = ABRICATE_RUN.out.report.collect{ meta, report -> report }.map{ report -> [[ id: 'test_summary'], report]}
+                """
+            }
+        }
+        then {
+            assert process.success
+            assert snapshot(process.out).match()
+        }
+    }
+
+    test("second test") {
+        when {
+            process {
+                """
+                input[0] = ABRICATE_RUN.out.report.collect{ meta, report -> report }.map{ report -> [[ id: 'test_summary'], report]}
+                """
+            }
+        }
+        then {
+            assert process.success
+            assert snapshot(process.out).match()
+        }
+    }
+
+}
+```

--- a/docs/docs/testcases/setup.md
+++ b/docs/docs/testcases/setup.md
@@ -38,6 +38,10 @@ run("WorkflowName") {
 }
 ```
 
+!!! warning
+
+    Please keep in mind that changes in procsses or workflows, which are executed in the setup method, can result in a failed test run.
+
 ## Example Usage
 
 ### 1. Local Setup Method

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,16 +4,16 @@ copyright: "&copy; 2021 - 2023 Lukas Forer and Sebastian Schönherr"
 theme:
   name: material
   features:
-      - content.tooltips
-      #- navigation.expand
-      - navigation.footer
-      - navigation.tabs
-      #- navigation.tabs.sticky
-      - search.highlight
-      - search.share
-      - search.suggest
-      - toc.integrate
-      - content.tabs.link
+    - content.tooltips
+    #- navigation.expand
+    - navigation.footer
+    - navigation.tabs
+    #- navigation.tabs.sticky
+    - search.highlight
+    - search.share
+    - search.suggest
+    - toc.integrate
+    - content.tabs.link
   font:
     text: Segoe UI
 
@@ -36,44 +36,44 @@ nav:
   - Home: index.md
   - Installation: installation.md
   - Documentation:
-    - Getting Started: docs/getting-started.md
-    - Writing Tests:
-      - Pipeline Testing: docs/testcases/nextflow_pipeline.md
-      - Workflow Testing: docs/testcases/nextflow_workflow.md
-      - Process Testing: docs/testcases/nextflow_process.md
-      - Function Testing: docs/testcases/nextflow_function.md
-      - Params Dictionary: docs/testcases/params.md
-      - Global Variables: docs/testcases/global_variables.md      
-    - Running Tests: docs/running-tests.md
-    - Writing Assertions:
-      - Power Assertions: docs/assertions/assertions.md
-      - Files: docs/assertions/files.md
-      - Snapshots: docs/assertions/snapshots.md
-      - Regular Expressions: docs/assertions/regular-expressions.md
-      - FASTA Files: docs/assertions/fasta.md
-      - Using Third-Party Libraries: docs/assertions/libraries.md
-    - Command Line Interface (CLI):
-      - init: docs/cli/init.md
-      - generate: docs/cli/generate.md
-      - test: docs/cli/test.md
-      - list: docs/cli/list.md
-      - clean: docs/cli/clean.md
-    - Configuration: docs/configuration.md
-    - Plugins:
-      - Available Plugins: https://code.askimed.com/nf-test-plugins
-      - Using Plugins: docs/plugins/using-plugins.md
-      - Developing Plugins: docs/plugins/developing-plugins.md
+      - Getting Started: docs/getting-started.md
+      - Writing Tests:
+          - Pipeline Testing: docs/testcases/nextflow_pipeline.md
+          - Workflow Testing: docs/testcases/nextflow_workflow.md
+          - Process Testing: docs/testcases/nextflow_process.md
+          - Function Testing: docs/testcases/nextflow_function.md
+          - Params Dictionary: docs/testcases/params.md
+          - Setup Method: docs/testcases/setup.md
+          - Global Variables: docs/testcases/global_variables.md
+      - Running Tests: docs/running-tests.md
+      - Writing Assertions:
+          - Power Assertions: docs/assertions/assertions.md
+          - Files: docs/assertions/files.md
+          - Snapshots: docs/assertions/snapshots.md
+          - Regular Expressions: docs/assertions/regular-expressions.md
+          - FASTA Files: docs/assertions/fasta.md
+          - Using Third-Party Libraries: docs/assertions/libraries.md
+      - Command Line Interface (CLI):
+          - init: docs/cli/init.md
+          - generate: docs/cli/generate.md
+          - test: docs/cli/test.md
+          - list: docs/cli/list.md
+          - clean: docs/cli/clean.md
+      - Configuration: docs/configuration.md
+      - Plugins:
+          - Available Plugins: https://code.askimed.com/nf-test-plugins
+          - Using Plugins: docs/plugins/using-plugins.md
+          - Developing Plugins: docs/plugins/developing-plugins.md
   - Resources: resources.md
   - About: about.md
-
 
 markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.tabbed:
-      alternate_style: true 
+      alternate_style: true
   - attr_list
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg 
+      emoji_generator: !!python/name:materialx.emoji.to_svg

--- a/src/main/java/com/askimed/nf/test/core/AbstractTest.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTest.java
@@ -76,7 +76,14 @@ public abstract class AbstractTest implements ITest {
 	}
 
 	public void config(String config) {
-		this.config = new File(config);
+		if (config == null) {
+			return;
+		}
+		if (parent.isRelative(config)) {
+			this.config = new File(parent.makeAbsolute(config));
+		} else {
+			this.config = new File(config);
+		}
 	}
 
 	public File getConfig() {
@@ -89,7 +96,7 @@ public abstract class AbstractTest implements ITest {
 		if (testDirectory == null) {
 			throw new IOException("Testcase setup failed: No home directory set");
 		}
-				
+
 		launchDir = initDirectory("Launch Directory", testDirectory, DIRECTORY_TESTS, getHash());
 		metaDir = initDirectory("Meta Directory", launchDir, DIRECTORY_META);
 		outputDir = initDirectory("Output Directory", launchDir, DIRECTORY_OUTPUT);
@@ -154,11 +161,11 @@ public abstract class AbstractTest implements ITest {
 
 	@Override
 	public String getHash() {
-		
+
 		if (parent == null || parent.getFilename() == null || getName() == null || getName().isEmpty()) {
 			throw new RuntimeException("Error generating hash");
 		}
-		
+
 		return hash(parent.getFilename() + getName());
 
 	}
@@ -254,7 +261,7 @@ public abstract class AbstractTest implements ITest {
 	public boolean isUpdateSnapshot() {
 		return updateSnapshot;
 	}
-	
+
 	@Override
 	public String toString() {
 		return getHash().substring(0, 8) + ": " + getName();

--- a/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
@@ -19,7 +19,7 @@ public abstract class AbstractTestSuite implements ITestSuite {
 
 	private File globalConfig = null;
 
-	private File localConfig = null;
+	private String localConfig = null;
 
 	private List<ITest> tests = new Vector<ITest>();
 
@@ -53,7 +53,7 @@ public abstract class AbstractTestSuite implements ITestSuite {
 	}
 
 	public String getScript() {
-		if (script != null && isRelative(script)) {
+		if (isRelative(script)) {
 			return makeAbsolute(script);
 		} else {
 			return script;
@@ -70,7 +70,7 @@ public abstract class AbstractTestSuite implements ITestSuite {
 		for (NamedClosure namedClosure : testClosures) {
 			String testName = namedClosure.name;
 			Closure closure = namedClosure.closure;
-			
+
 			ITest test = getNewTestInstance(testName);
 			test.setup(getHomeDirectory());
 			closure.setDelegate(test);
@@ -95,7 +95,7 @@ public abstract class AbstractTestSuite implements ITestSuite {
 	}
 
 	public void config(String config) {
-		this.localConfig = new File(config);
+		this.localConfig = config;
 	}
 
 	public void setName(String name) {
@@ -139,12 +139,15 @@ public abstract class AbstractTestSuite implements ITestSuite {
 		return globalConfig;
 	}
 
-	public void setLocalConfig(File localConfig) {
-		this.localConfig = localConfig;
-	}
-
 	public File getLocalConfig() {
-		return localConfig;
+		if (localConfig == null) {
+			return null;
+		}
+		if (isRelative(localConfig)) {
+			return new File(makeAbsolute(localConfig));
+		} else {
+			return new File(localConfig);
+		}
 	}
 
 	public File getHomeDirectory() {
@@ -223,14 +226,17 @@ public abstract class AbstractTestSuite implements ITestSuite {
 		return failedTests;
 	}
 
-	protected String makeAbsolute(String path) {
+	public String makeAbsolute(String path) {
 		return new File(directory, path).getAbsolutePath();
 	}
 
-	protected boolean isRelative(String path) {
+	public boolean isRelative(String path) {
+		if (path == null) {
+			return false;
+		}
 		return path.startsWith("../") || path.startsWith("./");
 	}
-	
+
 	@Override
 	public String toString() {
 		return name;

--- a/src/main/java/com/askimed/nf/test/lang/Dependency.java
+++ b/src/main/java/com/askimed/nf/test/lang/Dependency.java
@@ -1,0 +1,65 @@
+package com.askimed.nf.test.lang;
+
+import groovy.lang.Closure;
+
+public class Dependency {
+
+	private String script;
+
+	private String name;
+
+	private String mapping;
+
+	public Dependency(String name, Closure closure) {
+		this.name = name;
+		closure.setDelegate(this);
+		closure.setResolveStrategy(Closure.DELEGATE_FIRST);
+		closure.call();
+	}
+
+	public void script(String script) {
+		this.script = script;
+	}
+
+	public String getScript() {
+		return script;
+	}
+
+	public void setScript(String script) {
+		this.script = script;
+	}
+
+	public void process(Closure closure) {
+		closure.setDelegate(this);
+		closure.setResolveStrategy(Closure.DELEGATE_FIRST);
+		Object mapping = closure.call();
+		if (mapping != null) {
+			this.mapping = mapping.toString();
+		}
+	}
+
+	public void workflow(Closure closure) {
+		process(closure);
+	}
+
+	public void function(Closure closure) {
+		process(closure);
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getMapping() {
+		return mapping;
+	}
+
+	public void setMapping(String mapping) {
+		this.mapping = mapping;
+	}
+
+}

--- a/src/main/java/com/askimed/nf/test/lang/process/ProcessContext.java
+++ b/src/main/java/com/askimed/nf/test/lang/process/ProcessContext.java
@@ -1,6 +1,10 @@
 package com.askimed.nf.test.lang.process;
 
+import java.util.List;
+import java.util.Vector;
+
 import com.askimed.nf.test.core.ITest;
+import com.askimed.nf.test.lang.Dependency;
 import com.askimed.nf.test.lang.TestContext;
 
 import groovy.lang.Closure;
@@ -10,6 +14,8 @@ public class ProcessContext extends TestContext {
 	private Process process = new Process();
 
 	private Closure processClosure;
+
+	private List<Dependency> dependencies = new Vector<Dependency>();
 
 	public ProcessContext(ITest test) {
 		super(test);
@@ -43,5 +49,14 @@ public class ProcessContext extends TestContext {
 		}
 
 	}
-	
+
+	public void run(String process, Closure closure) {		
+		Dependency dependency = new Dependency(process, closure);		
+		dependencies.add(dependency);
+	}
+
+	public List<Dependency> getDependencies() {
+		return dependencies;
+	}
+
 }

--- a/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.codehaus.groovy.control.CompilationFailedException;
 
 import com.askimed.nf.test.core.AbstractTest;
+import com.askimed.nf.test.lang.Dependency;
 import com.askimed.nf.test.lang.TestCode;
 import com.askimed.nf.test.nextflow.NextflowCommand;
 import com.askimed.nf.test.util.AnsiText;
@@ -82,7 +83,7 @@ public class ProcessTest extends AbstractTest {
 	public void execute() throws Throwable {
 
 		super.execute();
-		
+
 		File script = new File(parent.getScript());
 
 		if (!script.exists()) {
@@ -91,6 +92,10 @@ public class ProcessTest extends AbstractTest {
 
 		context.init(this);
 
+		if (parent.getSetup() != null) {
+			parent.getSetup().execute(context);
+		}
+		
 		if (setup != null) {
 			setup.execute(context);
 		}
@@ -124,8 +129,8 @@ public class ProcessTest extends AbstractTest {
 		nextflow.setProfile(parent.getProfile());
 		File projectConfig = new File("nextflow.config");
 		if (projectConfig.exists()) {
-			nextflow.addConfig(projectConfig);	
-		}		
+			nextflow.addConfig(projectConfig);
+		}
 		nextflow.addConfig(parent.getGlobalConfigFile());
 		nextflow.addConfig(parent.getLocalConfig());
 		nextflow.addConfig(getConfig());
@@ -177,9 +182,26 @@ public class ProcessTest extends AbstractTest {
 			script = new File(script).getAbsolutePath();
 		}
 
+		// update dependency paths
+		for (Dependency dependency : context.getDependencies()) {
+			String _script = dependency.getScript();
+			if (_script == null) {
+				dependency.setScript(script);
+			} else {
+				if (parent.isRelative(_script)) {
+					_script = parent.makeAbsolute(_script);
+				}
+				if (!_script.startsWith("/") && !_script.startsWith("./")) {
+					_script = new File(_script).getAbsolutePath();
+				}
+				dependency.setScript(_script);
+			}
+		}
+
 		Map<Object, Object> binding = new HashMap<Object, Object>();
 		binding.put("process", parent.getProcess());
 		binding.put("script", script);
+		binding.put("dependencies", context.getDependencies());
 
 		// Get body of when closure
 		binding.put("mapping", context.getProcess().getMapping());

--- a/src/main/java/com/askimed/nf/test/lang/process/ProcessTestSuite.java
+++ b/src/main/java/com/askimed/nf/test/lang/process/ProcessTestSuite.java
@@ -4,13 +4,17 @@ import java.io.IOException;
 
 import com.askimed.nf.test.core.AbstractTestSuite;
 import com.askimed.nf.test.core.ITest;
+import com.askimed.nf.test.lang.TestCode;
 
 import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 
 public class ProcessTestSuite extends AbstractTestSuite {
 
 	private String process;
 
+	private TestCode setup;
+	
 	public void process(String process) {
 		this.process = process;
 	}
@@ -27,6 +31,14 @@ public class ProcessTestSuite extends AbstractTestSuite {
 		addTestClosure(name, closure);
 	}
 
+	public void setup(@DelegatesTo(value = ProcessTest.class, strategy = Closure.DELEGATE_ONLY) final Closure closure) {
+		setup = new TestCode(closure);
+	}
+	
+	public TestCode getSetup() {
+		return setup;
+	}
+	
 	@Override
 	protected ITest getNewTestInstance(String name) {
 		ProcessTest test = new ProcessTest(this);

--- a/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowContext.java
+++ b/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowContext.java
@@ -1,6 +1,10 @@
 package com.askimed.nf.test.lang.workflow;
 
+import java.util.List;
+import java.util.Vector;
+
 import com.askimed.nf.test.core.ITest;
+import com.askimed.nf.test.lang.Dependency;
 import com.askimed.nf.test.lang.TestContext;
 
 import groovy.lang.Closure;
@@ -11,10 +15,12 @@ public class WorkflowContext extends TestContext {
 
 	private Workflow workflow = new Workflow();
 
+	private List<Dependency> dependencies = new Vector<Dependency>();
+
 	public WorkflowContext(ITest test) {
 		super(test);
 	}
-	
+
 	public void workflow(Closure<Object> closure) {
 		workflowClosure = closure;
 	}
@@ -38,6 +44,15 @@ public class WorkflowContext extends TestContext {
 
 	public void setWorkflow(Workflow workflow) {
 		this.workflow = workflow;
+	}
+
+	public void run(String process, Closure closure) {
+		Dependency dependency = new Dependency(process, closure);
+		dependencies.add(dependency);
+	}
+
+	public List<Dependency> getDependencies() {
+		return dependencies;
 	}
 
 }

--- a/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTestSuite.java
+++ b/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTestSuite.java
@@ -4,12 +4,17 @@ import java.io.IOException;
 
 import com.askimed.nf.test.core.AbstractTestSuite;
 import com.askimed.nf.test.core.ITest;
+import com.askimed.nf.test.lang.TestCode;
+import com.askimed.nf.test.lang.process.ProcessTest;
 
 import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 
 public class WorkflowTestSuite extends AbstractTestSuite {
 
 	private String workflow;
+
+	private TestCode setup;
 
 	public void workflow(String workflow) {
 		this.workflow = workflow;
@@ -27,12 +32,19 @@ public class WorkflowTestSuite extends AbstractTestSuite {
 		addTestClosure(name, closure);
 	}
 
+	public void setup(@DelegatesTo(value = ProcessTest.class, strategy = Closure.DELEGATE_ONLY) final Closure closure) {
+		setup = new TestCode(closure);
+	}
+
+	public TestCode getSetup() {
+		return setup;
+	}
+
 	@Override
 	protected ITest getNewTestInstance(String name) {
 		WorkflowTest test = new WorkflowTest(this);
 		test.name(name);
 		return test;
 	}
-
 
 }

--- a/src/main/java/com/askimed/nf/test/util/Command.java
+++ b/src/main/java/com/askimed/nf/test/util/Command.java
@@ -14,8 +14,6 @@ public class Command {
 
 	private String directory = null;
 
-	private StringBuffer stdout = new StringBuffer();
-
 	private String stdoutFileName = null;
 
 	private String stderrFileName = null;
@@ -63,6 +61,8 @@ public class Command {
 		try {
 
 			ProcessBuilder builder = new ProcessBuilder(command);
+			// ensure it works on MacOS
+			builder.environment().put("PATH", builder.environment().get("PATH") + ":" + "/usr/local/bin/");
 			if (directory != null) {
 				builder.directory(new File(directory));
 			}
@@ -125,10 +125,6 @@ public class Command {
 			}
 		}
 		return result;
-	}
-
-	public String getStdOut() {
-		return stdout.toString();
 	}
 
 	public String getName() {

--- a/src/main/resources/com/askimed/nf/test/lang/process/WorkflowMock.nf
+++ b/src/main/resources/com/askimed/nf/test/lang/process/WorkflowMock.nf
@@ -6,10 +6,10 @@ nextflow.enable.dsl=2
 // comes from nf-test to store json files
 params.nf_test_output  = ""
 
-// process mapping
-def input = []
-${mapping}
-//----
+// include dependencies
+<% for (dependency in dependencies) { %>
+include { ${dependency.name} } from '${dependency.script}'
+<% } %>
 
 // include test process
 include { ${process} } from '${script}'
@@ -23,6 +23,20 @@ def jsonOutput =
 
 
 workflow {
+
+    // run dependencies
+    <% for (dependency in dependencies) { %>
+    {
+        def input = []
+        ${dependency.mapping}
+        ${dependency.name}(*input)
+    }
+    <% } %>
+
+    // process mapping
+    def input = []
+    ${mapping}
+    //----
 
     //run process
     ${process}(*input)

--- a/src/main/resources/com/askimed/nf/test/lang/workflow/WorkflowMock.nf
+++ b/src/main/resources/com/askimed/nf/test/lang/workflow/WorkflowMock.nf
@@ -6,12 +6,12 @@ nextflow.enable.dsl=2
 // comes from nf-test to store json files
 params.nf_test_output  = ""
 
-// process mapping
-def input = []
-${mapping}
-//----
+// include dependencies
+<% for (dependency in dependencies) { %>
+include { ${dependency.name} } from '${dependency.script}'
+<% } %>
 
-// include test process
+// include test workflow
 include { ${workflow} } from '${script}'
 
 // define custom rules for JSON that will be generated.
@@ -23,6 +23,20 @@ def jsonOutput =
 
 
 workflow {
+
+    // run dependencies
+    <% for (dependency in dependencies) { %>
+    {
+        def input = []
+        ${dependency.mapping}
+        ${dependency.name}(*input)
+    }
+    <% } %>
+
+    // workflow mapping
+    def input = []
+    ${mapping}
+    //----
 
     //run workflow
     ${workflow}(*input)

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -215,4 +215,23 @@ public class ProcessTest {
 
 	}
 	
+	@Test
+	public void testDependencies() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/dependencies/process_data.nf.test" });
+		assertEquals(0, exitCode);
+
+	}
+
+	@Test
+	public void testDependenciesAbricate() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/abricate/summary/tests/main.nf.test" });
+		assertEquals(0, exitCode);
+
+	}
+	
+	
 }

--- a/test-data/process/abricate/run/main.nf
+++ b/test-data/process/abricate/run/main.nf
@@ -1,0 +1,34 @@
+process ABRICATE_RUN {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "bioconda::abricate=1.0.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/abricate%3A1.0.1--ha8f3691_1':
+        'biocontainers/abricate:1.0.1--ha8f3691_1' }"
+
+    input:
+    tuple val(meta), path(assembly)
+
+    output:
+    tuple val(meta), path("*.txt"), emit: report
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    abricate \\
+        $assembly \\
+        $args \\
+        --threads $task.cpus > ${prefix}.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        abricate: \$(echo \$(abricate --version 2>&1) | sed 's/^.*abricate //' )
+    END_VERSIONS
+    """
+}

--- a/test-data/process/abricate/summary/main.nf
+++ b/test-data/process/abricate/summary/main.nf
@@ -1,0 +1,33 @@
+process ABRICATE_SUMMARY {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::abricate=1.0.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/abricate%3A1.0.1--ha8f3691_1':
+        'biocontainers/abricate:1.0.1--ha8f3691_1' }"
+
+    input:
+    tuple val(meta), path(reports)
+
+    output:
+    tuple val(meta), path("*.txt"), emit: report
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    abricate \\
+        --summary \\
+        $reports > ${prefix}.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        abricate: \$(echo \$(abricate --version 2>&1) | sed 's/^.*abricate //' )
+    END_VERSIONS
+    """
+}

--- a/test-data/process/abricate/summary/tests/main.nf.test
+++ b/test-data/process/abricate/summary/tests/main.nf.test
@@ -1,0 +1,45 @@
+nextflow_process {
+
+    name "Test process data"
+
+    script "../main.nf"
+    process "ABRICATE_SUMMARY"
+    config "./nextflow.config"
+
+    test("Should use process ABRICATE_RUN to generate input data") {
+
+        setup {
+            
+            run("ABRICATE_RUN") {
+                script "../../run/main.nf"
+                process {
+                    """
+                    input[0] =  Channel.fromList([
+                        tuple([ id:'test1', single_end:false ], // meta map
+                            file(params.test_data['bacteroides_fragilis']['genome']['genome_fna_gz'], checkIfExists: true)),
+                        tuple([ id:'test2', single_end:false ],
+                            file(params.test_data['haemophilus_influenzae']['genome']['genome_fna_gz'], checkIfExists: true))
+                    ])
+                    """
+                }
+            }
+
+        }
+
+
+
+        when {
+            process {
+                """
+                input[0] = ABRICATE_RUN.out.report.collect{ meta, report -> report }.map{ report -> [[ id: 'test_summary'], report]}
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out).match()
+        }
+    }
+
+}

--- a/test-data/process/abricate/summary/tests/main.nf.test.snap
+++ b/test-data/process/abricate/summary/tests/main.nf.test.snap
@@ -1,0 +1,31 @@
+{
+    "Should use process ABRICATE_RUN to generate input data": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_summary"
+                        },
+                        "test_summary.txt:md5,a4ec7010e75404ce3a1033f0c4b4a7f9"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,1fadc3c51127e35186a8f1d4ec21ea07"
+                ],
+                "report": [
+                    [
+                        {
+                            "id": "test_summary"
+                        },
+                        "test_summary.txt:md5,a4ec7010e75404ce3a1033f0c4b4a7f9"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,1fadc3c51127e35186a8f1d4ec21ea07"
+                ]
+            }
+        ],
+        "timestamp": "2023-10-05T13:55:50.988633"
+    }
+}

--- a/test-data/process/abricate/summary/tests/nextflow.config
+++ b/test-data/process/abricate/summary/tests/nextflow.config
@@ -1,0 +1,4 @@
+includeConfig 'https://raw.githubusercontent.com/nf-core/modules/master/tests/config/test_data.config'
+
+docker.enabled = true
+docker.registry = 'quay.io'

--- a/test-data/process/dependencies/generate_data.nf
+++ b/test-data/process/dependencies/generate_data.nf
@@ -1,0 +1,13 @@
+process GENERATE_DATA {
+
+  input:
+    val name
+
+  output:
+     path "*.txt", emit: results
+
+  """
+  echo "hello ${name}!" > "data.txt"
+  """
+
+}

--- a/test-data/process/dependencies/process_data.nf
+++ b/test-data/process/dependencies/process_data.nf
@@ -1,0 +1,17 @@
+process PROCESS_DATA {
+
+  publishDir "${params.outdir}", mode: 'copy'
+
+  input:
+  	val name 
+    path input
+
+  output:
+     path "output.txt", emit: results
+
+  """
+  	cp ${input} output.txt
+  	echo "hey ${name}!" >> "output.txt"
+  """
+
+}

--- a/test-data/process/dependencies/process_data.nf.test
+++ b/test-data/process/dependencies/process_data.nf.test
@@ -1,0 +1,36 @@
+nextflow_process {
+
+    name "Test process data"
+
+    script "./process_data.nf"
+    process "PROCESS_DATA"
+
+    test("Should use process GENERATE_DATA to generate input data") {
+
+        setup {
+            run("GENERATE_DATA") {
+                script "./generate_data.nf"
+                process {
+                    """
+                    input[0] = "nf-core"
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = "lukas"
+                input[1] = GENERATE_DATA.out.results
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out.results).match()
+        }
+    }
+
+}

--- a/test-data/process/dependencies/process_data.nf.test.snap
+++ b/test-data/process/dependencies/process_data.nf.test.snap
@@ -1,0 +1,10 @@
+{
+    "Should use process GENERATE_DATA to generate input data": {
+        "content": [
+            [
+                "output.txt:md5,cf78c141ba07d58cba270f3ccc5ee358"
+            ]
+        ],
+        "timestamp": "2023-10-05T12:41:15.52647"
+    }
+}


### PR DESCRIPTION
This pull  PR enables the execution of dependent modules for generating test data (Fixes #70).

With these changes, it is now possible to specify processes in the setup method that need to be executed before the `when` block. The outputs of these processes can then be utilized to define parameters or map processes/workflows. The `run`method takes the processs or workflow name, the (relativ) path to the script file and the input mapping as arguments.
 
For example, the following testcase for the `ABRICATE_SUMMARY` module executes the `ABRICATE_RUN` module to generate the input data:

```
nextflow_process {

    name "Test process data"

    script "../main.nf"
    process "ABRICATE_SUMMARY"
    config "./nextflow.config"

    test("Should use process ABRICATE_RUN to generate input data") {

        setup {
            
            run("ABRICATE_RUN") {
                script "../../run/main.nf"
                process {
                    """
                    input[0] =  Channel.fromList([
                        tuple([ id:'test1', single_end:false ], // meta map
                            file(params.test_data['bacteroides_fragilis']['genome']['genome_fna_gz'], checkIfExists: true)),
                        tuple([ id:'test2', single_end:false ],
                            file(params.test_data['haemophilus_influenzae']['genome']['genome_fna_gz'], checkIfExists: true))
                    ])
                    """
                }
            }

        }



        when {
            process {
                """
                input[0] = ABRICATE_RUN.out.report.collect{ meta, report -> report }.map{ report -> [[ id: 'test_summary'], report]}
                """
            }
        }

        then {
            assert process.success
            assert snapshot(process.out).match()
        }
    }

}
```

The full example can be found here: https://github.com/askimed/nf-test/tree/features/dependencies/test-data/process/abricate

It is also possible to define the `setup` method globally for all tests as follows:

```
nextflow_process {

    name "Test process data"

    script "../main.nf"
    process "ABRICATE_SUMMARY"
    config "./nextflow.config"

    setup {

        run("ABRICATE_RUN") {
            script "../../run/main.nf"
            process {
                """
                input[0] =  Channel.fromList([
                    tuple([ id:'test1', single_end:false ], // meta map
                        file(params.test_data['bacteroides_fragilis']['genome']['genome_fna_gz'], checkIfExists: true)),
                    tuple([ id:'test2', single_end:false ],
                        file(params.test_data['haemophilus_influenzae']['genome']['genome_fna_gz'], checkIfExists: true))
                ])
                """
            }
        }

    }


    test("first test") {

        when {
            process {
                """
                input[0] = ABRICATE_RUN.out.report.collect{ meta, report -> report }.map{ report -> [[ id: 'test_summary'], report]}
                """
            }
        }
	    ...
    }
    
    test("second test") {

        when {
            process {
                """
                input[0] = ABRICATE_RUN.out.report.collect{ meta, report -> report }.map{ report -> [[ id: 'test_summary'], report]}
                """
            }
        }
		...
    }

}
```

Open tasks:

- [x] Write documentation