### PR TITLE
Add possibility to set and combine multiple profiles

### DIFF
--- a/docs/docs/cli/test.md
+++ b/docs/docs/cli/test.md
@@ -10,45 +10,52 @@ nf-test test [<NEXTFLOW_FILES>|<SCRIPT_FOLDERS>]
 
 #### `--profile <NEXTFLOW_PROFILE>`
 
+To run your test using a specific Nextflow profile, you can use the `--profile` argument. [Learn more](/docs/configuration/#managing-profiles).
+
 #### `--debug`
+
 The debug parameter prints out all available output channels which can be accessed in the `then` clause.
 
 #### `--without-trace`
+
 The Linux tool `procps` is required to run Nextflow tracing. In case your container does not support this tool, you can also run nf-test without tracing. Please note that the `workflow.trace` are not available when running it with this flag.
 
 #### `--tag <tag>`
+
 Execute only tests with the provided tag. Multiple tags can be used and have to be separated by commas (e.g. `tag1,tag2`).
 
 #### `--tap <filename>`
+
 Writes test results in [TAP format](https://testanything.org) to file.
 
 #### `--junitxml <filename>`
+
 Writes test results in [JUnit XML format](https://junit.org/) to file, which conforms to [the standard schema](https://github.com/junit-team/junit5/blob/242f3b3ef84cfd96c9de26992588812a68cdef8b/platform-tests/src/test/resources/jenkins-junit.xsd).
 
 ## Examples
 
-* Run all test scripts that can be found in the `testDir` defined in the `nf-test.config` file in the current working directory:
+- Run all test scripts that can be found in the `testDir` defined in the `nf-test.config` file in the current working directory:
 
-    ```
-    nf-test test
-    ```
+  ```
+  nf-test test
+  ```
 
-* Run all specified test scripts and search specified directories for additional test scripts:
+- Run all specified test scripts and search specified directories for additional test scripts:
 
-    ```
-    nf-test test tests/modules/local/salmon_index.nf.test tests/modules/bwa_index.nf.test
+  ```
+  nf-test test tests/modules/local/salmon_index.nf.test tests/modules/bwa_index.nf.test
 
-    nf-test test tests/modules tests/modules/bwa_index.nf.test
-    ```
+  nf-test test tests/modules tests/modules/bwa_index.nf.test
+  ```
 
-* Run a specific test using its hash:
+- Run a specific test using its hash:
 
-    ```
-    nf-test test tests/main.nf.test@d41119e4
-    ```
+  ```
+  nf-test test tests/main.nf.test@d41119e4
+  ```
 
-* Run all tests and write results to `report.tap`:
+- Run all tests and write results to `report.tap`:
 
-    ```
-    nf-test test --tap report.tap
-    ```
+  ```
+  nf-test test --tap report.tap
+  ```

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1,31 +1,31 @@
 # Configuration
 
-## Setup test profile
+## `nf-test.config`
 
-To run your test using a specific Nextflow profile, you can use the `--profile` argument on the command line or define a default profile in `nf-test.config`.
+The `nf-test.config` file is a configuration file used to customize settings and behavior for `nf-test`. This file must be located in the root of your project, and it is automatically loaded when you run `nf-test test`. Below are the parameters that can be adapted:
 
+| Parameter    | Description                                                                                                                                                        | Default Value             |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------- |
+| `testsDir`   | Location for storing all nf-test cases (test scripts). If you want all test files to be in the same directory as the script itself, you can set the testDir to `.` | `"tests"`                 |
+| `workDir`    | Directory for storing temporary files and working directories for each test. This directory should be added to `.gitignore`.                                       | `".nf-test"`              |
+| `configFile` | Location of an optional `nextflow.config` file specifically used for executing tests. [Learn more](#testsnextflowconfig).                                          | `"tests/nextflow.config"` |
+| `libDir`     | Location of a library folder that is automatically added to the classpath during testing to include additional libraries or resources needed for test cases.       | `"tests/lib"`             |
+| `profile`    | Default profile to use for running tests defined in the Nextflow configuration. See [Learn more](#managing-profiles).                                              | `"docker"`                |
+| `withTrace`  | Enable or disable tracing options during testing. Disable tracing if your containers don't include the `procps` tool.                                              | `true`                    |
+| `autoSort`   | Enable or disable sorted channels by default when running tests.                                                                                                   | `true`                    |
+| `options`    | Custom Nextflow command-line options to be applied when running tests. For example `"-dump-channels -stub-run"`                                                    |                           |
 
-##  `nf-test.config`
-
-This config file contains settings for nf-test.
+Here's an example of what an `nf-test.config` file could look like:
 
 ```groovy
 config {
-    // location for all nf-tests
     testsDir "tests"
-    // nf-test directory including temporary files for each test
     workDir ".nf-test"
-    // location of an optional nextflow.config file specific for executing tests
     configFile "tests/nextflow.config"
-    // location of library folder that is added automatically to the classpath
-    libDir "tests/lib"    
-    // run all test with the defined docker profile from the main nextflow.config
+    libDir "tests/lib"
     profile "docker"
-    // disable tracing options in case container does not include `procps` Linux tool.
     withTrace false
-    //disable sorted channels
     autoSort false
-    // add Nextflow options
     options "-dump-channels -stub-run"
 }
 ```
@@ -43,7 +43,7 @@ params {
 
 ## Configuration for tests
 
-nf-test allows to set an additional configuration for a testsuite:
+nf-test allows to set and overwrite the `config`, `autoSort` and `options` properties for a specific testsuite:
 
 ```
 nextflow_process {
@@ -59,7 +59,7 @@ nextflow_process {
 }
 ```
 
-It is also possible to overwrite the `config`, `autoSort` or Nextflow properties (e.g. `options "-dump-channels"`) for a specific test. Depending on the used Nextflow option, also add the `--debug` nf-test option on the command-line to see the addtional output.  
+It is also possible to overwrite these properties for specific test. Depending on the used Nextflow option, also add the `--debug` nf-test option on the command-line to see the addtional output.
 
 ```
 nextflow_process {
@@ -75,3 +75,27 @@ nextflow_process {
 
 }
 ```
+
+## Managing Profiles
+
+Profiles in `nf-test` provide a convenient way to configure and customize Nextflow executions for your test cases. To run your test using a specific Nextflow profile, you can use the `--profile` argument on the command line or define a default profile in `nf-test.config`.
+
+### Basic Profile Usage
+
+By default, `nf-test` reads the profile configuration from `nf-test.config`. If you've defined a profile called `A` in `nf-test.config`, running `nf-test --profile B` will start Nextflow with only the `B` profile. It replaces any existing profiles.
+
+### Combining Profiles with "+"
+
+To combine profiles, you can use the `+` prefix. For example, running `nf-test --profile +B` will start Nextflow with both `A` and `B` profiles, resulting in `-profile A,B`. This allows you to extend the existing configuration with additional profiles.
+
+### Profile Priority Order
+
+Profiles are evaluated in a specific order, ensuring predictable behavior:
+
+1. **Profile in nf-test.config:** The first profile considered is the one defined in `nf-test.config`.
+
+2. **Profile Defined in Testcase:** If you specify a profile within a testcase, it takes precedence over the one in `nf-test.config`.
+
+3. **Profile Defined on the Command Line (CLI):** Finally, any profiles provided directly through the CLI have the highest priority and override/extends previously defined profiles.
+
+By understanding this profile evaluation order, you can effectively configure Nextflow executions for your test cases in a flexible and organized manner.

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -68,6 +68,11 @@ public class RunTestsCommand extends AbstractCommand {
 			"--lib" }, description = "Library extension path", required = false, showDefaultValue = Visibility.ALWAYS)
 	private String lib = "";
 
+	@Option(names = { "--config",
+			"-c" }, description = "nf-test.config filename", required = false, showDefaultValue = Visibility.ALWAYS)
+
+	private String configFilename = Config.FILENAME;
+
 	@Option(names = {
 			"--plugins" }, description = "Library extension path", required = false, showDefaultValue = Visibility.ALWAYS)
 	private String plugins = null;
@@ -86,17 +91,14 @@ public class RunTestsCommand extends AbstractCommand {
 
 		try {
 
-			String defaultProfile = null;
 			File defaultConfigFile = null;
 			String libDir = lib;
 			boolean defaultWithTrace = true;
 			try {
-
-				File configFile = new File(Config.FILENAME);
+				File configFile = new File(configFilename);
 				if (configFile.exists()) {
 
 					Config config = Config.parse(configFile);
-					defaultProfile = config.getProfile();
 					defaultConfigFile = config.getConfigFile();
 					defaultWithTrace = config.isWithTrace();
 					if (!libDir.isEmpty()) {
@@ -164,12 +166,7 @@ public class RunTestsCommand extends AbstractCommand {
 			engine.setCleanSnapshot(cleanSnapshot);
 			engine.setLibDir(libDir);
 			engine.setPluginManager(manager);
-
-			if (profile != null) {
-				engine.setProfile(profile);
-			} else {
-				engine.setProfile(defaultProfile);
-			}
+			engine.addProfile(profile);
 			if (withoutTrace) {
 				engine.setWithTrace(false);
 			} else {

--- a/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
@@ -15,7 +15,7 @@ public abstract class AbstractTestSuite implements ITestSuite {
 
 	private String name;
 
-	private String profile = null;
+	private List<String> profiles = new Vector<String>();;
 
 	private File globalConfig = null;
 
@@ -46,6 +46,9 @@ public abstract class AbstractTestSuite implements ITestSuite {
 		autoSort = config.isAutoSort();
 		options = config.getOptions();
 		homeDirectory = new File(config.getWorkDir());
+		if (config.getProfile() != null) {
+			addProfile(config.getProfile());
+		}
 	}
 
 	public void script(String script) {
@@ -91,7 +94,7 @@ public abstract class AbstractTestSuite implements ITestSuite {
 	}
 
 	public void profile(String profile) {
-		this.profile = profile;
+		this.profiles.add(profile);
 	}
 
 	public void config(String config) {
@@ -106,12 +109,12 @@ public abstract class AbstractTestSuite implements ITestSuite {
 		return name;
 	}
 
-	public void setProfile(String profile) {
-		this.profile = profile;
+	public void addProfile(String profile) {
+		this.profiles.add(profile);
 	}
 
-	public String getProfile() {
-		return profile;
+	public List<String> getProfiles() {
+		return profiles;
 	}
 
 	public void autoSort(boolean autoSort) {

--- a/src/main/java/com/askimed/nf/test/core/ITestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/ITestSuite.java
@@ -12,7 +12,7 @@ public interface ITestSuite extends ITaggable {
 
 	public String getName();
 
-	public void setProfile(String profile);
+	public void addProfile(String profile);
 
 	public void setGlobalConfigFile(File config);
 

--- a/src/main/java/com/askimed/nf/test/lang/function/FunctionTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/function/FunctionTest.java
@@ -123,7 +123,9 @@ public class FunctionTest extends AbstractTest {
 		NextflowCommand nextflow = new NextflowCommand();
 		nextflow.setScript(workflow.getAbsolutePath());
 		nextflow.setParams(context.getParams());
-		nextflow.setProfile(parent.getProfile());
+		for (String profile: parent.getProfiles()) {
+			nextflow.addProfile(profile);
+		}
 		File projectConfig = new File("nextflow.config");
 		if (projectConfig.exists()) {
 			nextflow.addConfig(projectConfig);	

--- a/src/main/java/com/askimed/nf/test/lang/pipeline/PipelineTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/pipeline/PipelineTest.java
@@ -103,7 +103,9 @@ public class PipelineTest extends AbstractTest {
 		NextflowCommand nextflow = new NextflowCommand();
 		nextflow.setScript(script);
 		nextflow.setParams(context.getParams());
-		nextflow.setProfile(parent.getProfile());
+		for (String profile: parent.getProfiles()) {
+			nextflow.addProfile(profile);
+		}
 		File projectConfig = new File("nextflow.config");
 		if (projectConfig.exists()) {
 			nextflow.addConfig(projectConfig);	

--- a/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/process/ProcessTest.java
@@ -121,7 +121,9 @@ public class ProcessTest extends AbstractTest {
 		NextflowCommand nextflow = new NextflowCommand();
 		nextflow.setScript(workflow.getAbsolutePath());
 		nextflow.setParams(context.getParams());
-		nextflow.setProfile(parent.getProfile());
+		for (String profile: parent.getProfiles()) {
+			nextflow.addProfile(profile);
+		}
 		File projectConfig = new File("nextflow.config");
 		if (projectConfig.exists()) {
 			nextflow.addConfig(projectConfig);	

--- a/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTest.java
+++ b/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowTest.java
@@ -133,7 +133,9 @@ public class WorkflowTest extends AbstractTest {
 		NextflowCommand nextflow = new NextflowCommand();
 		nextflow.setScript(workflow.getAbsolutePath());
 		nextflow.setParams(context.getParams());
-		nextflow.setProfile(parent.getProfile());
+		for (String profile: parent.getProfiles()) {
+			nextflow.addProfile(profile);
+		}
 		File projectConfig = new File("nextflow.config");
 		if (projectConfig.exists()) {
 			nextflow.addConfig(projectConfig);	

--- a/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
+++ b/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
@@ -8,6 +8,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,7 +24,7 @@ public class NextflowCommand {
 
 	private String script;
 
-	private String profile;
+	private List<String> profiles = new Vector<String>();
 
 	private List<File> configs = new Vector<File>();
 
@@ -61,8 +62,17 @@ public class NextflowCommand {
 		this.script = script;
 	}
 
-	public void setProfile(String profile) {
-		this.profile = profile;
+	public void addProfile(String profile) {
+		if (profile == null) {
+			return;
+		}
+		if (!profile.startsWith("+")) {
+			this.profiles.clear();
+		}
+		String[] tiles = profile.split(",");
+		for (String tile : tiles) {
+			this.profiles.add(tile.replace("+", "").trim());
+		}
 	}
 
 	public void addConfig(File config) {
@@ -173,9 +183,9 @@ public class NextflowCommand {
 		args.add(paramsFile.getAbsolutePath());
 		args.add("-ansi-log");
 		args.add("false");
-		if (profile != null) {
+		if (!profiles.isEmpty()) {
 			args.add("-profile");
-			args.add(profile);
+			args.add(String.join(",", profiles));
 		}
 		if (trace != null) {
 			args.add("-with-trace");
@@ -202,8 +212,10 @@ public class NextflowCommand {
 		}
 		if (!silent) {
 			System.out.println();
-			System.out.println("    Nextflow Command:");
-			System.out.println("      " + nextflow.getExecutedCommand());
+			System.out.println("    Nextflow:");
+			System.out.println("       Profiles: " + profiles);
+			System.out.println("       Configs: " + configs);
+			System.out.println("       Command: " + nextflow.getExecutedCommand());
 		}
 
 		int result = nextflow.execute();

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -19,8 +19,8 @@ public class ProcessTest {
 
 	static {
 
-		 AnsiColors.disable();
-		 AnsiText.disable();
+		AnsiColors.disable();
+		AnsiText.disable();
 
 	}
 
@@ -38,7 +38,7 @@ public class ProcessTest {
 		assertEquals(0, exitCode);
 
 	}
-	
+
 	@Test
 	public void testExample() throws Exception {
 
@@ -48,18 +48,19 @@ public class ProcessTest {
 
 	}
 
-	/*@Test
-	public void testDisableAutoSortConfig() throws Exception {
+	/*
+	 * @Test public void testDisableAutoSortConfig() throws Exception {
+	 * 
+	 * Files.copy(Paths.get("test-data", "autosort.nf.test"),
+	 * Paths.get("nf-test.config"));
+	 * 
+	 * App app = new App(); int exitCode = app.run(new String[] { "test",
+	 * "test-data/process/autosort/test_process.nf.test" }); // Fails, because
+	 * expects sorted channels assertEquals(1, exitCode);
+	 * 
+	 * }
+	 */
 
-		Files.copy(Paths.get("test-data", "autosort.nf.test"), Paths.get("nf-test.config"));
-
-		App app = new App();
-		int exitCode = app.run(new String[] { "test", "test-data/process/autosort/test_process.nf.test" });
-		// Fails, because expects sorted channels
-		assertEquals(1, exitCode);
-
-	}*/
-	
 	@Test
 	public void testDisableAutoSortTestSuite() throws Exception {
 
@@ -69,7 +70,7 @@ public class ProcessTest {
 		assertEquals(1, exitCode);
 
 	}
-	
+
 	@Test
 	public void testDisableAutoSortTestSuiteAndOverwrite() throws Exception {
 
@@ -96,7 +97,7 @@ public class ProcessTest {
 		assertEquals(1, exitCode);
 
 	}
-	
+
 	@Test
 	public void testMissingScript() throws Exception {
 
@@ -178,7 +179,7 @@ public class ProcessTest {
 		assertEquals(0, exitCode);
 
 	}
-	
+
 	@Test
 	public void testLoadGzip() throws Exception {
 
@@ -187,7 +188,7 @@ public class ProcessTest {
 		assertEquals(0, exitCode);
 
 	}
-	
+
 	@Test
 	public void testLoadGzipWithModuleDir() throws Exception {
 
@@ -196,7 +197,7 @@ public class ProcessTest {
 		assertEquals(0, exitCode);
 
 	}
-	
+
 	@Test
 	public void testScriptWithRelativePath() throws Exception {
 
@@ -205,14 +206,63 @@ public class ProcessTest {
 		assertEquals(0, exitCode);
 
 	}
-	
+
 	@Test
 	public void testScriptWithRelativePathInSubfolder() throws Exception {
 
 		App app = new App();
-		int exitCode = app.run(new String[] { "test", "test-data/process/default/tests/test_process_relative.nf.test" });
+		int exitCode = app
+				.run(new String[] { "test", "test-data/process/default/tests/test_process_relative.nf.test" });
 		assertEquals(0, exitCode);
 
 	}
-	
+
+	@Test
+	public void testProfiles() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/profiles/hello.a.nf.test" });
+		assertEquals(0, exitCode);
+
+		app = new App();
+		exitCode = app
+				.run(new String[] { "test", "test-data/process/profiles/hello.a.nf.test", "--profile", "profile_b" });
+		assertEquals(1, exitCode);
+
+	}
+
+	@Test
+	public void testProfilesOverwrite() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/profiles/hello.b.nf.test" });
+		assertEquals(1, exitCode);
+
+		app = new App();
+		exitCode = app
+				.run(new String[] { "test", "test-data/process/profiles/hello.b.nf.test", "--profile", "profile_b" });
+		assertEquals(0, exitCode);
+
+	}
+
+	@Test
+	public void testProfilesOverwriteInConfig() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/profiles/hello.a.nf.test", "--config",
+				"test-data/process/profiles/nf-test.config" });
+		assertEquals(0, exitCode);
+
+		app = new App();
+		exitCode = app.run(new String[] { "test", "test-data/process/profiles/hello.c.nf.test", "--config",
+				"test-data/process/profiles/nf-test.config", "--profile", "profile_b" });
+		assertEquals(1, exitCode);
+
+		app = new App();
+		exitCode = app.run(new String[] { "test", "test-data/process/profiles/hello.b.nf.test", "--config",
+				"test-data/process/profiles/nf-test.config", "--profile", "profile_b" });
+		assertEquals(0, exitCode);
+
+	}
+
 }

--- a/test-data/process/profiles/hello.a.nf.test
+++ b/test-data/process/profiles/hello.a.nf.test
@@ -1,0 +1,27 @@
+nextflow_process {
+
+  name "Test process HELLO"
+
+  script "./hello.nf"
+  process "HELLO"
+  config "test-data/process/profiles/nextflow.config"
+  profile "profile_a"
+
+  test("Should create 5 files") {
+
+    when {
+      process {
+        """
+        input[0] = params.name
+        """
+      }
+    }
+
+    then {
+      assert process.success
+      assert "Hello profile_a!" in workflow.stdout
+    }
+
+  }
+
+}

--- a/test-data/process/profiles/hello.b.nf.test
+++ b/test-data/process/profiles/hello.b.nf.test
@@ -1,0 +1,27 @@
+nextflow_process {
+
+  name "Test process HELLO"
+
+  script "./hello.nf"
+  process "HELLO"
+  config "test-data/process/profiles/nextflow.config"
+  profile "profile_a"
+
+  test("Should create 5 files") {
+
+    when {
+      process {
+        """
+        input[0] = params.name
+        """
+      }
+    }
+
+    then {
+      assert process.success
+      assert "Hello profile_b!" in workflow.stdout
+    }
+
+  }
+
+}

--- a/test-data/process/profiles/hello.c.nf.test
+++ b/test-data/process/profiles/hello.c.nf.test
@@ -1,0 +1,27 @@
+nextflow_process {
+
+  name "Test process HELLO"
+
+  script "./hello.nf"
+  process "HELLO"
+  config "test-data/process/profiles/nextflow.config"
+  profile "profile_a"
+
+  test("Should create 5 files") {
+
+    when {
+      process {
+        """
+        input[0] = params.name
+        """
+      }
+    }
+
+    then {
+      assert process.success
+      assert "Hello profile_c!" in workflow.stdout
+    }
+
+  }
+
+}

--- a/test-data/process/profiles/hello.nf
+++ b/test-data/process/profiles/hello.nf
@@ -1,0 +1,11 @@
+process HELLO {
+
+  input:
+    val name
+
+  script:
+    println "Hello ${name}!"
+  """
+  """
+
+}

--- a/test-data/process/profiles/nextflow.config
+++ b/test-data/process/profiles/nextflow.config
@@ -1,0 +1,26 @@
+profiles {
+
+    standard {
+        params.name = "no profile"
+    }
+
+
+    profile_b {
+        params {
+            name = "profile_b"
+        }
+    }
+
+    profile_c {
+        params {
+            name = "profile_c"
+        }
+    }
+
+
+     profile_a {
+        params {
+            name = "profile_a"
+        }
+    }   
+}

--- a/test-data/process/profiles/nf-test.config
+++ b/test-data/process/profiles/nf-test.config
@@ -1,0 +1,4 @@
+config {
+    profile "profile_b"
+    configFile ""
+}


### PR DESCRIPTION
This PR fixes #94.

### Basic Profile Usage

By default, `nf-test` reads the profile configuration from `nf-test.config`. If you've defined a profile called `A` in `nf-test.config`, running `nf-test --profile B` will start Nextflow with only the `B` profile. It replaces any existing profiles.

### Combining Profiles with "+"

To combine profiles, you can use the `+` prefix. For example, running `nf-test --profile +B` will start Nextflow with both `A` and `B` profiles, resulting in `-profile A,B`. This allows you to extend the existing configuration with additional profiles.

### Profile Priority Order

Profiles are evaluated in a specific order, ensuring predictable behavior:

1. **Profile in nf-test.config:** The first profile considered is the one defined in `nf-test.config`.

2. **Profile Defined in Testcase:** If you specify a profile within a testcase, it takes precedence over the one in `nf-test.config`.

3. **Profile Defined on the Command Line (CLI):** Finally, any profiles provided directly through the CLI have the highest priority and override/extends previously defined profiles.

By understanding this profile evaluation order, you can effectively configure Nextflow executions for your test cases in a flexible and organized manner.
