### PR TITLE
calculate md5 hash of .gz files based on file content

### DIFF
--- a/docs/docs/assertions/files.md
+++ b/docs/docs/assertions/files.md
@@ -7,6 +7,8 @@ nf-test extends `path` by a `md5` property that can be used to compare the file 
 ```Groovy
 assert path(process.out.out_ch.get(0)).md5 == "64debea5017a035ddc67c0b51fa84b16"
 ```
+Note that for gzip compressed files, the `md5` property is calculated after gunzipping the file contents, whereas for other filetypes the `md5` property is directly
+calculated on the file itself.
 
 ## JSON Files
 nf-test supports comparison of JSON files and keys within JSON files.

--- a/src/main/java/com/askimed/nf/test/util/FileUtil.java
+++ b/src/main/java/com/askimed/nf/test/util/FileUtil.java
@@ -115,6 +115,8 @@ public class FileUtil {
 				md.update(buffer, 0, read);
 				read = gzis.read(buffer);
 			}
+			gzis.close();
+			fis.close();
 		// for other files, calculate md5 hash directly from file
 		} else {
 			md.update(Files.readAllBytes(self));

--- a/src/main/java/com/askimed/nf/test/util/FileUtil.java
+++ b/src/main/java/com/askimed/nf/test/util/FileUtil.java
@@ -105,7 +105,21 @@ public class FileUtil {
 	public static String getMd5(Path self) throws IOException, NoSuchAlgorithmException {
 		Formatter fm = new Formatter();
 		MessageDigest md = MessageDigest.getInstance("MD5");
-		md.update(Files.readAllBytes(self));
+		// for .gz files, calculate md5 hash on decompressed content
+		if (self.toString().endsWith(".gz")) {
+			FileInputStream fis = new FileInputStream(self.toString());
+			GZIPInputStream gzis = new GZIPInputStream(fis);
+			byte[] buffer = new byte[4096];
+			int read = gzis.read(buffer);
+			while ( read >= 0) {
+				md.update(buffer, 0, read);
+				read = gzis.read(buffer);
+			}
+		// for other files, calculate md5 hash directly from file
+		} else {
+			md.update(Files.readAllBytes(self));
+	
+		}
 		byte[] md5sum = md.digest();
 		for (byte b : md5sum) {
 			fm.format("%02x", b);


### PR DESCRIPTION
This  PR changes the way that md5 hashes are calculated from gzip files as described in #141. In short: for `.gz` files only, the md5 hash is now calculated on the decompressed file contents, equivalent to:

```bash
gunzip -c file.gz | md5sum
```
As mentioned in the issue, this will break previously defined assertions/snapshots on gzip files 