### PR TITLE
docs: add explicit file snapshot example

### DIFF
--- a/docs/docs/assertions/snapshots.md
+++ b/docs/docs/assertions/snapshots.md
@@ -20,6 +20,12 @@ You can also create a snapshot of all output channels of a process:
 assert snapshot(process.out).match()
 ```
 
+Or a specific check on a file:
+
+```Groovy
+assert snapshot(path(process.out.get(0)).md5).match()
+```
+
 Even the result of a function can be used:
 
 ```Groovy

--- a/docs/docs/assertions/snapshots.md
+++ b/docs/docs/assertions/snapshots.md
@@ -23,7 +23,7 @@ assert snapshot(process.out).match()
 Or a specific check on a file:
 
 ```Groovy
-assert snapshot(path(process.out.get(0)).md5).match()
+assert snapshot(path(process.out.get(0))).match()
 ```
 
 Even the result of a function can be used:


### PR DESCRIPTION
Might not be the cleanest example, but it's something that tripped me up (and possibly others at nf-core) when looking at the docs - as in I wasn't sure exactly what the scope of an 'object' was.

I know that there is a dedicated 'file paths' section, but I feel having a specific example of a file snapshot in the 'landing page' of the Snapshot page might be useful as it is a  very common check (i.e., has the file contents changed between runs?).

Feel free to change the example to a simpler one if you wish.