### PR TITLE
split on lines in CommandStreamHandler

### DIFF
--- a/src/main/java/com/askimed/nf/test/util/CommandStreamHandler.java
+++ b/src/main/java/com/askimed/nf/test/util/CommandStreamHandler.java
@@ -37,7 +37,7 @@ public class CommandStreamHandler implements Runnable {
 			boolean save = (filename != null && !filename.isEmpty());
 			FileOutputStream writer = null;
 
-			byte[] buffer = new byte[200];
+			byte[] buffer = new byte[1024];
 
 			if (save) {
 				writer = new FileOutputStream(filename);
@@ -47,8 +47,11 @@ public class CommandStreamHandler implements Runnable {
 
 			while ((size = is.read(buffer)) > 0) {
 				if (!silent) {
-					String line = new String(buffer, 0, size);
-					System.out.print("    > " + line);
+					String[] lines = new String(buffer, 0, size).split("\n");
+					for(int i = 0; i < lines.length; i++) {
+					    System.out.println("    > " + lines[i]);
+					}
+
 				}
 				if (save) {
 					writer.write(buffer, 0, size);

--- a/src/main/java/com/askimed/nf/test/util/CommandStreamHandler.java
+++ b/src/main/java/com/askimed/nf/test/util/CommandStreamHandler.java
@@ -1,23 +1,21 @@
 package com.askimed.nf.test.util;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 
 public class CommandStreamHandler implements Runnable {
 
-	private InputStream is;
+	private BufferedReader is;
 
 	private boolean silent = false;
 
 	private String filename = null;
 
 	public CommandStreamHandler(InputStream is) {
-		this.is = is;
+		this.is = new BufferedReader(new InputStreamReader(is));
 	}
 
 	public CommandStreamHandler(InputStream is, String filename) {
-		this.is = is;
+		this.is = new BufferedReader(new InputStreamReader(is));
 		this.filename = filename;
 	}
 
@@ -35,26 +33,22 @@ public class CommandStreamHandler implements Runnable {
 		try {
 
 			boolean save = (filename != null && !filename.isEmpty());
-			FileOutputStream writer = null;
+			BufferedWriter writer = null;
 
-			byte[] buffer = new byte[1024];
+			byte[] buffer = new byte[200];
 
 			if (save) {
-				writer = new FileOutputStream(filename);
+				writer = new BufferedWriter(new FileWriter(filename));
 			}
 
-			int size = 0;
-
-			while ((size = is.read(buffer)) > 0) {
+			String line = null;
+			while ((line = is.readLine()) != null) {
 				if (!silent) {
-					String[] lines = new String(buffer, 0, size).split("\n");
-					for(int i = 0; i < lines.length; i++) {
-					    System.out.println("    > " + lines[i]);
-					}
-
+					System.out.println("    > " + line);
 				}
 				if (save) {
-					writer.write(buffer, 0, size);
+					writer.write(line);
+					writer.newLine();
 				}
 			}
 

--- a/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
+++ b/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
@@ -13,7 +13,7 @@ public class CommandStreamHandlerTest {
 
     @Test
     public void testCommandStreamHandler() {
-        // output snippet taken from nextflow run nf-core/rnaseq -revision 3.4
+        // output snippet taken from `nextflow run nf-core/rnaseq -revision 3.4`
         String commandOutput =
             "------------------------------------------------------\n"
           + "If you use nf-core/rnaseq for your analysis please cite:\n"

--- a/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
+++ b/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 
 public class CommandStreamHandlerTest {
 
-	@Test
-	public void testCommandStreamHandler() {
+    @Test
+    public void testCommandStreamHandler() {
         // output snippet taken from nextflow run nf-core/rnaseq -revision 3.4
         String commandOutput =
             "------------------------------------------------------\n"
@@ -28,17 +28,17 @@ public class CommandStreamHandlerTest {
           + "  https://github.com/nf-core/rnaseq/blob/master/CITATIONS.md\n"
           + "------------------------------------------------------\n";
 
-		// capture stdout
-		PrintStream stdout = System.out;
-		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        // capture stdout
+        PrintStream stdout = System.out;
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out));
 
         ByteArrayInputStream is = new ByteArrayInputStream(commandOutput.getBytes());
-		CommandStreamHandler handler = new CommandStreamHandler((InputStream) is);
-		handler.run();
+        CommandStreamHandler handler = new CommandStreamHandler((InputStream) is);
+        handler.run();
 
-		// stop capturing stdout
-		System.setOut(stdout);
+        // stop capturing stdout
+        System.setOut(stdout);
 
         String expectedOutput =
             "    > ------------------------------------------------------\n"
@@ -54,9 +54,9 @@ public class CommandStreamHandlerTest {
           + "    >   https://github.com/nf-core/rnaseq/blob/master/CITATIONS.md\n"
           + "    > ------------------------------------------------------\n";
 
-		assertEquals(
-		    expectedOutput,
-		    out.toString()
-		);
-	}
+        assertEquals(
+            expectedOutput,
+            out.toString()
+        );
+    }
 }

--- a/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
+++ b/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
@@ -13,11 +13,7 @@ public class CommandStreamHandlerTest {
 
 	@Test
 	public void testCommandStreamHandler() {
-		// capture stdout
-		PrintStream stdout = System.out;
-		final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
-
+        // output snippet taken from nextflow run nf-core/rnaseq -revision 3.4
         String commandOutput =
             "------------------------------------------------------\n"
           + "If you use nf-core/rnaseq for your analysis please cite:\n"
@@ -32,9 +28,17 @@ public class CommandStreamHandlerTest {
           + "  https://github.com/nf-core/rnaseq/blob/master/CITATIONS.md\n"
           + "------------------------------------------------------\n";
 
+		// capture stdout
+		PrintStream stdout = System.out;
+		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
         ByteArrayInputStream is = new ByteArrayInputStream(commandOutput.getBytes());
 		CommandStreamHandler handler = new CommandStreamHandler((InputStream) is);
 		handler.run();
+
+		// stop capturing stdout
+		System.setOut(stdout);
 
         String expectedOutput =
             "    > ------------------------------------------------------\n"
@@ -54,7 +58,5 @@ public class CommandStreamHandlerTest {
 		    expectedOutput,
 		    out.toString()
 		);
-
-		System.setOut(stdout);
 	}
 }

--- a/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
+++ b/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
@@ -30,11 +30,11 @@ public class CommandStreamHandlerTest {
 
         // capture stdout
         PrintStream stdout = System.out;
-        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out));
 
         ByteArrayInputStream is = new ByteArrayInputStream(commandOutput.getBytes());
-        CommandStreamHandler handler = new CommandStreamHandler((InputStream) is);
+        CommandStreamHandler handler = new CommandStreamHandler(is);
         handler.run();
 
         // stop capturing stdout

--- a/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
+++ b/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
@@ -7,9 +7,20 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.InputStream;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class CommandStreamHandlerTest {
+    ByteArrayOutputStream out;
+    PrintStream stdout;
+
+    @BeforeEach
+    public void captureStandardOut() {
+        stdout = System.out;
+        out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+    }
 
     @Test
     public void testCommandStreamHandler() {
@@ -28,17 +39,9 @@ public class CommandStreamHandlerTest {
           + "  https://github.com/nf-core/rnaseq/blob/master/CITATIONS.md\n"
           + "------------------------------------------------------\n";
 
-        // capture stdout
-        PrintStream stdout = System.out;
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
-
         ByteArrayInputStream is = new ByteArrayInputStream(commandOutput.getBytes());
         CommandStreamHandler handler = new CommandStreamHandler(is);
         handler.run();
-
-        // stop capturing stdout
-        System.setOut(stdout);
 
         String expectedOutput =
             "    > ------------------------------------------------------\n"
@@ -58,5 +61,10 @@ public class CommandStreamHandlerTest {
             expectedOutput,
             out.toString()
         );
+    }
+
+    @AfterEach
+    public void resetStandardOut() {
+        System.setOut(stdout);
     }
 }

--- a/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
+++ b/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
@@ -1,0 +1,60 @@
+package com.askimed.nf.test.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+
+public class CommandStreamHandlerTest {
+
+	@Test
+	public void testCommandStreamHandler() {
+		// capture stdout
+		PrintStream stdout = System.out;
+		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        String commandOutput =
+            "------------------------------------------------------\n"
+          + "If you use nf-core/rnaseq for your analysis please cite:\n"
+          + "\n"
+          + "* The pipeline\n"
+          + "  https://doi.org/10.5281/zenodo.1400710\n"
+          + "\n"
+          + "* The nf-core framework\n"
+          + "  https://doi.org/10.1038/s41587-020-0439-x\n"
+          + "\n"
+          + "* Software dependencies\n"
+          + "  https://github.com/nf-core/rnaseq/blob/master/CITATIONS.md\n"
+          + "------------------------------------------------------\n";
+
+        ByteArrayInputStream is = new ByteArrayInputStream(commandOutput.getBytes());
+		CommandStreamHandler handler = new CommandStreamHandler((InputStream) is);
+		handler.run();
+
+        String expectedOutput =
+            "    > ------------------------------------------------------\n"
+          + "    > If you use nf-core/rnaseq for your analysis please cite:\n"
+          + "    > \n"
+          + "    > * The pipeline\n"
+          + "    >   https://doi.org/10.5281/zenodo.1400710\n"
+          + "    > \n"
+          + "    > * The nf-core framework\n"
+          + "    >   https://doi.org/10.1038/s41587-020-0439-x\n"
+          + "    > \n"
+          + "    > * Software dependencies\n"
+          + "    >   https://github.com/nf-core/rnaseq/blob/master/CITATIONS.md\n"
+          + "    > ------------------------------------------------------\n";
+
+		assertEquals(
+		    expectedOutput,
+		    out.toString()
+		);
+
+		System.setOut(stdout);
+	}
+}

--- a/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
+++ b/src/test/java/com/askimed/nf/test/util/CommandStreamHandlerTest.java
@@ -12,14 +12,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class CommandStreamHandlerTest {
-    ByteArrayOutputStream out;
-    PrintStream stdout;
+    final ByteArrayOutputStream capturedOut = new ByteArrayOutputStream();
+    final PrintStream stdout = System.out;
 
     @BeforeEach
     public void captureStandardOut() {
-        stdout = System.out;
-        out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
+        System.setOut(new PrintStream(capturedOut));
     }
 
     @Test
@@ -59,12 +57,13 @@ public class CommandStreamHandlerTest {
 
         assertEquals(
             expectedOutput,
-            out.toString()
+            capturedOut.toString()
         );
     }
 
     @AfterEach
     public void resetStandardOut() {
         System.setOut(stdout);
+        capturedOut.reset();
     }
 }


### PR DESCRIPTION
Add a `CommandStreamHandler` test case that demonstrates current improper handling, and add logic to fix it by splitting on lines. Fixes https://github.com/askimed/nf-test/issues/166

There is an example of a failing test case demonstrating the issue on my fork [here](https://github.com/ahvigil/nf-test/actions/runs/7282081625/job/19843802984) which gets [resolved](https://github.com/ahvigil/nf-test/actions/runs/7282084885/job/19843812182) with this change.
```
Error:  Failures: 
Error:    CommandStreamHandlerTest.testCommandStreamHandler:53 expected: <    > ------------------------------------------------------
    > If you use nf-core/rnaseq for your analysis please cite:
    > 
    > * The pipeline
    >   https://doi.org/10.5281/zenodo.1400710
    > 
    > * The nf-core framework
    >   https://doi.org/10.1038/s41587-020-0439-x
    > 
    > * Software dependencies
    >   https://github.com/nf-core/rnaseq/blob/master/CITATIONS.md
    > ------------------------------------------------------
> but was: <    > ------------------------------------------------------
If you use nf-core/rnaseq for your analysis please cite:

* The pipeline
  https://doi.org/10.5281/zenodo.1400710

* The nf-core framework
  http    > s://doi.org/10.1038/s41587-020-0439-x

* Software dependencies
  https://github.com/nf-core/rnaseq/blob/master/CITATIONS.md
------------------------------------------------------
>
```

This doesn't handle lines that might get split up across multiple reads but I bumped the buffer size up to 1K to reduce the chances of this. Could resolve this more elegantly if we made sure to read up to the next newline instead of blindly taking whatever `read(...)` returns in its buffer.

The test case was taken from a snippet of the output of `nextflow run nf-core/rnaseq -revision 3.4` which has some generic nf-core boiilerplate.