### PR TITLE
Set default staging mode in config file

### DIFF
--- a/src/main/java/com/askimed/nf/test/config/Config.java
+++ b/src/main/java/com/askimed/nf/test/config/Config.java
@@ -38,6 +38,8 @@ public class Config {
 
 	private StageBuilder stageBuilder = new StageBuilder();
 
+	private String stageMode = FileStaging.MODE_COPY;
+
 	public void testsDir(String testsDir) {
 		this.testsDir = testsDir;
 	}
@@ -112,6 +114,18 @@ public class Config {
 
 	public String getLibDir() {
 		return libDir;
+	}
+
+	public void setStageMode(String stageMode) {
+		this.stageMode = stageMode;
+	}
+
+	public String getStageMode() {
+		return stageMode;
+	}
+
+	public void stageMode(String stageMode) {
+		this.stageMode = stageMode;
 	}
 
 	public void stage(Closure closure) {

--- a/src/main/java/com/askimed/nf/test/core/AbstractTest.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTest.java
@@ -107,9 +107,9 @@ public abstract class AbstractTest implements ITest {
 		outputDir = initDirectory("Output Directory", launchDir, DIRECTORY_OUTPUT);
 		workDir = initDirectory("Working Directory", launchDir, DIRECTORY_WORK);
 		FileStaging[] sharedDirectories = new FileStaging[]{
-				new FileStaging("bin", config.getStageMode()),
-				new FileStaging("lib",  config.getStageMode()),
-				new FileStaging("assets", config.getStageMode())
+				new FileStaging("bin", config != null ? config.getStageMode() : FileStaging.MODE_COPY),
+				new FileStaging("lib",  config != null ? config.getStageMode() : FileStaging.MODE_COPY),
+				new FileStaging("assets", config != null ? config.getStageMode() : FileStaging.MODE_COPY)
 		};
 		try {
 			// copy bin, assets and lib to metaDir

--- a/src/main/java/com/askimed/nf/test/core/AbstractTest.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTest.java
@@ -59,9 +59,6 @@ public abstract class AbstractTest implements ITest {
 
 	public boolean skipped = false;
 
-	public static FileStaging[] SHARED_DIRECTORIES = { new FileStaging("bin"), new FileStaging("lib"),
-			new FileStaging("assets") };
-
 	protected File config = null;
 
 	private boolean updateSnapshot = false;
@@ -109,10 +106,14 @@ public abstract class AbstractTest implements ITest {
 		metaDir = initDirectory("Meta Directory", launchDir, DIRECTORY_META);
 		outputDir = initDirectory("Output Directory", launchDir, DIRECTORY_OUTPUT);
 		workDir = initDirectory("Working Directory", launchDir, DIRECTORY_WORK);
-
+		FileStaging[] sharedDirectories = new FileStaging[]{
+				new FileStaging("bin", config.getStageMode()),
+				new FileStaging("lib",  config.getStageMode()),
+				new FileStaging("assets", config.getStageMode())
+		};
 		try {
 			// copy bin, assets and lib to metaDir
-			shareDirectories(SHARED_DIRECTORIES, metaDir);
+			shareDirectories(sharedDirectories, metaDir);
 			if (config != null) {
 				// copy user defined staging directories
 				log.debug("Stage {} user provided files...", config.getStageBuilder().getPaths().size());


### PR DESCRIPTION
This PR sets the default file-staging mode to `copy` and adds a property to the config file to change it.

It could be changed to symlink with:

```
config {
    stageMode "symlink"
}
```

This should help to investigate and understand issue #149 