### PR TITLE
Add property to set alias for dependencies

### DIFF
--- a/src/main/java/com/askimed/nf/test/lang/Dependency.java
+++ b/src/main/java/com/askimed/nf/test/lang/Dependency.java
@@ -2,16 +2,25 @@ package com.askimed.nf.test.lang;
 
 import groovy.lang.Closure;
 
+import java.util.Map;
+
 public class Dependency {
 
 	private String script;
 
 	private String name;
 
+	private String alias;
+
 	private String mapping;
 
-	public Dependency(String name, Closure closure) {
+	public static final String ATTRIBUTE_ALIAS = "alias";
+
+	public Dependency(String name, Map<String, Object> attributes, Closure closure) {
 		this.name = name;
+		if (attributes.containsKey(ATTRIBUTE_ALIAS)) {
+			this.alias = attributes.get(ATTRIBUTE_ALIAS).toString();
+		}
 		closure.setDelegate(this);
 		closure.setResolveStrategy(Closure.DELEGATE_FIRST);
 		closure.call();
@@ -52,6 +61,18 @@ public class Dependency {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	public String getAlias() {
+		return alias;
+	}
+
+	public void setAlias(String alias) {
+		this.alias = alias;
+	}
+
+	public boolean hasAlias() {
+		return alias != null;
 	}
 
 	public String getMapping() {

--- a/src/main/java/com/askimed/nf/test/lang/process/ProcessContext.java
+++ b/src/main/java/com/askimed/nf/test/lang/process/ProcessContext.java
@@ -1,6 +1,8 @@
 package com.askimed.nf.test.lang.process;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import com.askimed.nf.test.core.ITest;
@@ -50,9 +52,13 @@ public class ProcessContext extends TestContext {
 
 	}
 
-	public void run(String process, Closure closure) {		
-		Dependency dependency = new Dependency(process, closure);		
+	public void run(Map<String, Object> attributes, String process, Closure closure) {
+		Dependency dependency = new Dependency(process, attributes, closure);
 		dependencies.add(dependency);
+	}
+
+	public void run(String process, Closure closure) {
+		run(new LinkedHashMap<String, Object>(), process, closure);
 	}
 
 	public List<Dependency> getDependencies() {

--- a/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowContext.java
+++ b/src/main/java/com/askimed/nf/test/lang/workflow/WorkflowContext.java
@@ -1,6 +1,8 @@
 package com.askimed.nf.test.lang.workflow;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import com.askimed.nf.test.core.ITest;
@@ -46,9 +48,13 @@ public class WorkflowContext extends TestContext {
 		this.workflow = workflow;
 	}
 
-	public void run(String process, Closure closure) {
-		Dependency dependency = new Dependency(process, closure);
+	public void run(Map<String, Object> attributes, String process, Closure closure) {
+		Dependency dependency = new Dependency(process, attributes, closure);
 		dependencies.add(dependency);
+	}
+
+	public void run(String process, Closure closure) {
+		run(new LinkedHashMap<String, Object>(), process, closure);
 	}
 
 	public List<Dependency> getDependencies() {

--- a/src/main/resources/com/askimed/nf/test/lang/process/WorkflowMock.nf
+++ b/src/main/resources/com/askimed/nf/test/lang/process/WorkflowMock.nf
@@ -8,7 +8,7 @@ params.nf_test_output  = ""
 
 // include dependencies
 <% for (dependency in dependencies) { %>
-include { ${dependency.name} } from '${dependency.script}'
+include { ${dependency.name} ${dependency.hasAlias() ? " as " + dependency.alias : "" } } from '${dependency.script}'
 <% } %>
 
 // include test process
@@ -29,7 +29,7 @@ workflow {
     {
         def input = []
         ${dependency.mapping}
-        ${dependency.name}(*input)
+        ${dependency.hasAlias() ? dependency.alias : dependency.name}(*input)
     }
     <% } %>
 

--- a/src/main/resources/com/askimed/nf/test/lang/workflow/WorkflowMock.nf
+++ b/src/main/resources/com/askimed/nf/test/lang/workflow/WorkflowMock.nf
@@ -8,7 +8,7 @@ params.nf_test_output  = ""
 
 // include dependencies
 <% for (dependency in dependencies) { %>
-include { ${dependency.name} } from '${dependency.script}'
+include { ${dependency.name} ${dependency.hasAlias() ? " as " + dependency.alias : "" } } from '${dependency.script}'
 <% } %>
 
 // include test workflow
@@ -29,7 +29,7 @@ workflow {
     {
         def input = []
         ${dependency.mapping}
-        ${dependency.name}(*input)
+        ${dependency.hasAlias() ? dependency.alias : dependency.name}(*input)
     }
     <% } %>
 

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -139,7 +139,7 @@ public class ProcessTest {
 
 		App app = new App();
 		int exitCode = app
-				.run(new String[] { "test", "test-data/process/path-util/test_process.nf.test", "--update-snapshot" });
+				.run(new String[] { "test", "test-data/process/path-util/test_process_success.nf.test", "--update-snapshot" });
 		assertEquals(0, exitCode);
 
 	}
@@ -148,7 +148,7 @@ public class ProcessTest {
 	public void testBinFolder() throws Exception {
 
 		App app = new App();
-		int exitCode = app.run(new String[] { "test", "test-data/process/bin-folder/test_process.nf.test" });
+		int exitCode = app.run(new String[] { "test", "test-data/process/bin-folder/test_process_success.nf.test" });
 		assertEquals(0, exitCode);
 
 	}

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -34,7 +34,7 @@ public class ProcessTest {
 	public void testScriptSucces() throws Exception {
 
 		App app = new App();
-		int exitCode = app.run(new String[] { "test", "test-data/process/default/test_process.nf.test" });
+		int exitCode = app.run(new String[] { "test", "test-data/process/default/test_process_success.nf.test" });
 		assertEquals(0, exitCode);
 
 	}
@@ -139,7 +139,7 @@ public class ProcessTest {
 
 		App app = new App();
 		int exitCode = app
-				.run(new String[] { "test", "test-data/process/path-util/test_process_success.nf.test", "--update-snapshot" });
+				.run(new String[] { "test", "test-data/process/path-util/test_process.nf.test", "--update-snapshot" });
 		assertEquals(0, exitCode);
 
 	}

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -34,7 +34,7 @@ public class ProcessTest {
 	public void testScriptSucces() throws Exception {
 
 		App app = new App();
-		int exitCode = app.run(new String[] { "test", "test-data/process/default/test_process_success.nf.test" });
+		int exitCode = app.run(new String[] { "test", "test-data/process/default/test_process.nf.test" });
 		assertEquals(0, exitCode);
 
 	}
@@ -148,7 +148,7 @@ public class ProcessTest {
 	public void testBinFolder() throws Exception {
 
 		App app = new App();
-		int exitCode = app.run(new String[] { "test", "test-data/process/bin-folder/test_process_success.nf.test" });
+		int exitCode = app.run(new String[] { "test", "test-data/process/bin-folder/test_process.nf.test" });
 		assertEquals(0, exitCode);
 
 	}
@@ -221,9 +221,17 @@ public class ProcessTest {
 	public void testDependencies() throws Exception {
 
 		App app = new App();
-		int exitCode = app.run(new String[] { "test", "test-data/process/dependencies/process_data.nf.test" });
+		int exitCode = app.run(new String[] { "test", "test-data/process/dependencies/process_data.nf.test", "--verbose" });
   
-  }
+  	}
+
+	@Test
+	public void testDependenciesWithAlias() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/dependencies/process_data_alias.nf.test", "--verbose" });
+
+	}
   
   @Test
 	public void testDependenciesAbricate() throws Exception {

--- a/test-data/process/dependencies/process_data_alias.nf.test
+++ b/test-data/process/dependencies/process_data_alias.nf.test
@@ -1,0 +1,36 @@
+nextflow_process {
+
+    name "Test process data"
+
+    script "./process_data.nf"
+    process "PROCESS_DATA"
+
+    test("Should use process GENERATE_DATA with alias PROCESS_ALIAS to generate input data") {
+
+        setup {
+            run("GENERATE_DATA", alias: "LUKAS") {
+                script "./generate_data.nf"
+                process {
+                    """
+                    input[0] = "nf-core"
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = "lukas"
+                input[1] = LUKAS.out.results
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out.results).match()
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds the parameter `alias` to the run method to define the alias for dependencies. This address issue #139 

Example:

```
run("GENERATE_DATA", alias: "LUKAS") {
    script "./generate_data.nf"
    process {
        """
        input[0] = "nf-core"
        """
    }
}
```