### PR TITLE
Fix issue with relative paths in channel serialization

### DIFF
--- a/src/main/resources/com/askimed/nf/test/lang/function/WorkflowMock.nf
+++ b/src/main/resources/com/askimed/nf/test/lang/function/WorkflowMock.nf
@@ -21,7 +21,7 @@ include { ${include} } from '${script}'
 def jsonOutput =
     new JsonGenerator.Options()
         .excludeNulls()  // Do not include fields with value null..
-        .addConverter(Path) { value -> value.toString() } // Custom converter for Path. Only filename
+        .addConverter(Path) { value -> value.toAbsolutePath().toString() } // Custom converter for Path. Only filename
         .build()
 
 

--- a/src/main/resources/com/askimed/nf/test/lang/process/WorkflowMock.nf
+++ b/src/main/resources/com/askimed/nf/test/lang/process/WorkflowMock.nf
@@ -18,7 +18,7 @@ include { ${process} } from '${script}'
 def jsonOutput =
     new JsonGenerator.Options()
         .excludeNulls()  // Do not include fields with value null..
-        .addConverter(Path) { value -> value.toString() } // Custom converter for Path. Only filename
+        .addConverter(Path) { value -> value.toAbsolutePath().toString() } // Custom converter for Path. Only filename
         .build()
 
 

--- a/src/main/resources/com/askimed/nf/test/lang/workflow/WorkflowMock.nf
+++ b/src/main/resources/com/askimed/nf/test/lang/workflow/WorkflowMock.nf
@@ -18,7 +18,7 @@ include { ${workflow} } from '${script}'
 def jsonOutput =
     new JsonGenerator.Options()
         .excludeNulls()  // Do not include fields with value null..
-        .addConverter(Path) { value -> value.toString() } // Custom converter for Path. Only filename
+        .addConverter(Path) { value -> value.toAbsolutePath().toString() } // Custom converter for Path. Only filename
         .build()
 
 


### PR DESCRIPTION
This PR writes always the absolute path to the channel's json file to ensure that snapshots are able to pick up files. This fixes #173 