### PR TITLE
Throw error when a snapshot with same id was created multiple time

### DIFF
--- a/src/main/java/com/askimed/nf/test/lang/extensions/Snapshot.java
+++ b/src/main/java/com/askimed/nf/test/lang/extensions/Snapshot.java
@@ -28,6 +28,13 @@ public class Snapshot {
 	}
 
 	public boolean match(String id) throws IOException {
+
+		//check if match with this id was already called. --> duplicate snapshots.
+		if (file.getActiveSnapshots().contains(id)) {
+			throw new RuntimeException("A snapshot with id '" + id + "' already exists. " +
+					"Snapshot ids have to be unique, and a test can only have one unnamed snapshot.");
+		}
+
 		SnapshotFileItem expected = file.getSnapshot(id);
 		// new snapshot --> create snapshot
 		if (expected == null) {

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -282,4 +282,20 @@ public class ProcessTest {
 
 	}
 
+	@Test
+	public void testUniquenessSnapshots() throws Exception {
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/snapshots/unique.nf.test" });
+		assertEquals(0, exitCode);
+	}
+
+	@Test
+	public void testNotUniquenessOfSnapshots() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/snapshots/not-unique.nf.test" });
+		assertEquals(1, exitCode);
+
+	}
+
 }

--- a/test-data/process/snapshots/no-unique.test
+++ b/test-data/process/snapshots/no-unique.test
@@ -1,0 +1,28 @@
+nextflow_process {
+
+  name "Test process xy"
+
+  script "./process.nf"
+  process "TEST_PROCESS"
+
+  test("Should fail because two unnamed snapshots") {
+
+    when {
+      process {
+        """
+        input[0] = "Lukas"
+        """
+      }
+    }
+
+    then {
+      assert process.success
+      assert process.out.my_output_files
+      assert process.out.my_output_files.size() == 1
+      assert snapshot(process.out.my_output_files).match()
+      assert snapshot(process.out.my_output_files).match()
+    }
+
+  }
+
+}

--- a/test-data/process/snapshots/process.nf
+++ b/test-data/process/snapshots/process.nf
@@ -1,0 +1,13 @@
+process TEST_PROCESS {
+
+  input:
+    val name
+
+  output:
+     path "*.txt", emit: my_output_files
+
+  """
+  echo "Hello ${name}!" > output.txt
+  """
+
+}

--- a/test-data/process/snapshots/unique.nf.test
+++ b/test-data/process/snapshots/unique.nf.test
@@ -1,0 +1,28 @@
+nextflow_process {
+
+  name "Test process xy"
+
+  script "./process.nf"
+  process "TEST_PROCESS"
+
+  test("Should succeed because two unique snapshots") {
+
+    when {
+      process {
+        """
+        input[0] = "Lukas"
+        """
+      }
+    }
+
+    then {
+      assert process.success
+      assert process.out.my_output_files
+      assert process.out.my_output_files.size() == 1
+      assert snapshot(process.out.my_output_files).match()
+      assert snapshot(process.out.my_output_files).match("lukas")
+    }
+
+  }
+
+}

--- a/test-data/process/snapshots/unique.nf.test.snap
+++ b/test-data/process/snapshots/unique.nf.test.snap
@@ -1,0 +1,18 @@
+{
+    "Should succeed because two unique snapshots": {
+        "content": [
+            [
+                "output.txt:md5,286d2f149346ef78d42276aaf0f32693"
+            ]
+        ],
+        "timestamp": "2024-01-27T13:02:28.820175"
+    },
+    "lukas": {
+        "content": [
+            [
+                "output.txt:md5,286d2f149346ef78d42276aaf0f32693"
+            ]
+        ],
+        "timestamp": "2024-01-27T13:02:28.826437"
+    }
+}


### PR DESCRIPTION
Throws an error when a user creates more than one unnamed snapshot or mutiple snapshots with the same id to avoid unexpected snapshot matching. Fixes #158 