### PR TITLE
Add nf-test and nextflow version to snapshots

### DIFF
--- a/src/main/java/com/askimed/nf/test/commands/AbstractCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/AbstractCommand.java
@@ -3,6 +3,7 @@ package com.askimed.nf.test.commands;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
+import com.askimed.nf.test.nextflow.NextflowCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
 
 		log.info(App.NAME + " " + App.VERSION);
 		log.info("Arguments: " + Arrays.toString(App.args));
+		log.info("Nextflow Version: " + NextflowCommand.getVersion());
 
 		if (!silent) {
 			printHeader();
@@ -48,7 +50,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
 		System.out.println();
 		System.out.println(Emoji.ROCKET + AnsiText.bold(" " + App.NAME + " " + App.VERSION));
 		System.out.println("https://code.askimed.com/nf-test");
-		System.out.println("(c) 2021 - 2023 Lukas Forer and Sebastian Schoenherr");
+		System.out.println("(c) 2021 - 2024 Lukas Forer and Sebastian Schoenherr");
 		System.out.println();
 
 	}

--- a/src/main/java/com/askimed/nf/test/lang/extensions/SnapshotFile.java
+++ b/src/main/java/com/askimed/nf/test/lang/extensions/SnapshotFile.java
@@ -61,6 +61,9 @@ public class SnapshotFile {
 			String timestamp = object.get("timestamp").toString();
 			Object content = object.get("content");
 			SnapshotFileItem item = new SnapshotFileItem(timestamp, content);
+			if (object.containsKey("meta")) {
+				item.setMeta((Map<String, Object>) object.get("meta"));
+			}
 			snapshots.put(id, item);
 		}
 		log.debug("Load snapshots from file '{}'", filename);

--- a/src/main/java/com/askimed/nf/test/lang/extensions/SnapshotFileItem.java
+++ b/src/main/java/com/askimed/nf/test/lang/extensions/SnapshotFileItem.java
@@ -2,9 +2,13 @@ package com.askimed.nf.test.lang.extensions;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 
+import com.askimed.nf.test.App;
 import com.askimed.nf.test.lang.extensions.util.SnapshotDiffUtil;
 
+import com.askimed.nf.test.nextflow.NextflowCommand;
 import groovy.json.JsonGenerator;
 import groovy.json.JsonOutput;
 
@@ -14,16 +18,19 @@ public class SnapshotFileItem {
 
 	private String timestamp;
 
+	private Map<String, Object> meta = new HashMap<>();
+
 	public static DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
 
 	public SnapshotFileItem(Object content) {
-		this.timestamp = createTimestamp();
-		this.content = content;
+		this(SnapshotFileItem.createTimestamp(), content);
 	}
 
 	public SnapshotFileItem(String timestamp, Object content) {
 		this.timestamp = timestamp;
 		this.content = content;
+		this.meta.put(App.NAME, App.VERSION);
+		this.meta.put("nextflow", NextflowCommand.getVersion());
 	}
 
 	public Object getContent() {
@@ -32,6 +39,14 @@ public class SnapshotFileItem {
 
 	public String getTimestamp() {
 		return timestamp;
+	}
+
+	public Map<String, Object> getMeta() {
+		return meta;
+	}
+
+	public void setMeta(Map<String, Object> meta) {
+		this.meta = meta;
 	}
 
 	@Override
@@ -55,7 +70,7 @@ public class SnapshotFileItem {
 
 	}
 
-	protected String createTimestamp() {
+	public static String createTimestamp() {
 		return DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.now());
 	}
 

--- a/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
+++ b/src/main/java/com/askimed/nf/test/nextflow/NextflowCommand.java
@@ -296,6 +296,48 @@ public class NextflowCommand {
 
 	}
 
+	private static String version = null;
+
+	public static String getVersion(){
+		if (version == null){
+			try {
+				version = new NextflowCommand().parseVersion();
+			} catch (Exception e){
+				version = "unknown";
+			}
+		}
+		return version;
+	}
+
+	public String parseVersion() throws IOException {
+
+		if (binary == null) {
+			throw new IOException(ERROR);
+		}
+
+		List<String> args = new Vector<String>();
+		args.add("-version");
+
+		Command nextflow = new Command(binary);
+		nextflow.setParams(args);
+		nextflow.setSilent(true);
+		StringBuffer output = new StringBuffer();
+		nextflow.writeStderr(output);
+		nextflow.execute();
+		String versionPattern = "version (\\d+\\.\\d+\\.\\d+)";
+		Pattern pattern = Pattern.compile(versionPattern);
+		Matcher matcher = pattern.matcher(output);
+
+		if (matcher.find()) {
+			return matcher.group(1);
+		} else {
+			return "unknown";
+		}
+
+	}
+
+
+
 	protected void writeParamsJson(Map<String, Object> params, File paramsFile) throws IOException {
 
 		BufferedWriter writer = new BufferedWriter(new FileWriter(paramsFile));

--- a/src/main/java/com/askimed/nf/test/util/Command.java
+++ b/src/main/java/com/askimed/nf/test/util/Command.java
@@ -18,6 +18,10 @@ public class Command {
 
 	private String stderrFileName = null;
 
+	private StringBuffer stdout;
+
+	private StringBuffer stderr;
+
 	public Command(String cmd, String... params) {
 		this.cmd = cmd;
 		this.params = params;
@@ -37,6 +41,15 @@ public class Command {
 			this.params[i] = params.get(i);
 		}
 	}
+
+	public void writeStdout(StringBuffer stdout) {
+		this.stdout = stdout;
+	}
+
+	public void writeStderr(StringBuffer stderr) {
+		this.stderr = stderr;
+	}
+
 
 	public void saveStdOut(String filename) {
 		this.stdoutFileName = filename;
@@ -69,10 +82,12 @@ public class Command {
 
 			Process process = builder.start();
 			CommandStreamHandler handler = new CommandStreamHandler(process.getInputStream(), stdoutFileName);
+			handler.setStringBuffer(stdout);
 			handler.setSilent(silent);
 			Thread inputStreamHandler = new Thread(handler);
 
 			CommandStreamHandler handler2 = new CommandStreamHandler(process.getErrorStream(), stderrFileName);
+			handler.setStringBuffer(stderr);
 			handler2.setSilent(silent);
 			Thread errorStreamHandler = new Thread(handler2);
 

--- a/src/main/java/com/askimed/nf/test/util/CommandStreamHandler.java
+++ b/src/main/java/com/askimed/nf/test/util/CommandStreamHandler.java
@@ -10,6 +10,8 @@ public class CommandStreamHandler implements Runnable {
 
 	private String filename = null;
 
+	private StringBuffer memory;
+
 	public CommandStreamHandler(InputStream is) {
 		this.is = new BufferedReader(new InputStreamReader(is));
 	}
@@ -21,6 +23,10 @@ public class CommandStreamHandler implements Runnable {
 
 	public void setSilent(boolean silent) {
 		this.silent = silent;
+	}
+
+	public void setStringBuffer(StringBuffer memory) {
+		this.memory = memory;
 	}
 
 	public void setFilename(String filename) {
@@ -43,6 +49,9 @@ public class CommandStreamHandler implements Runnable {
 
 			String line = null;
 			while ((line = is.readLine()) != null) {
+				if (memory != null) {
+					memory.append(line).append("\n");
+				}
 				if (!silent) {
 					System.out.println("    > " + line);
 				}


### PR DESCRIPTION
This PR adds a property `meta` to a snapshot containing the versions used to create it. Fixes #170 

Example:

```
    "Should succeed ....": {
        "content": [
            [
                "output.txt:md5,286d2f149346ef78d42276aaf0f32693"
            ]
        ],
        "meta": {
            "nf-test": "0.8.3",
            "nextflow": "23.04.3"
        },
        "timestamp": "2024-01-27T14:24:56.05131"
    }
```