### PR TITLE
Add `md5()` function to snapshot

### DIFF
--- a/docs/docs/assertions/snapshots.md
+++ b/docs/docs/assertions/snapshots.md
@@ -105,6 +105,14 @@ You can also use helper methods to add objects to snapshots. For example, you ca
  assert snapshot(workflow, path(params.outdir).list()).match()
 ```
 
+## Compressed Snapshots
+
+If you add complex objects to snapshots with large content, you could use the `md5()` function to store the hashsum instead of the content in the snapshot file:
+
+```Groovy
+ assert snapshot(hugeObject).md5().match()
+```
+
 ## File Paths
 
 If nf-test detects a path in the snapshot it automatically replace it by a unique *fingerprint* of the file that ensures the file content is the same. The fingerprint is default the md5 sum.

--- a/src/main/java/com/askimed/nf/test/lang/extensions/Snapshot.java
+++ b/src/main/java/com/askimed/nf/test/lang/extensions/Snapshot.java
@@ -1,11 +1,11 @@
 package com.askimed.nf.test.lang.extensions;
 
-import java.io.IOException;
-
+import com.askimed.nf.test.core.ITest;
+import com.askimed.nf.test.util.ObjectUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.askimed.nf.test.core.ITest;
+import java.io.IOException;
 
 public class Snapshot {
 
@@ -25,6 +25,11 @@ public class Snapshot {
 
 	public boolean match() throws IOException {
 		return match(test.getName());
+	}
+
+	public Snapshot md5() {
+		actual = ObjectUtil.getMd5(actual);
+		return this;
 	}
 
 	public boolean match(String id) throws IOException {

--- a/src/main/java/com/askimed/nf/test/lang/extensions/SnapshotFileItem.java
+++ b/src/main/java/com/askimed/nf/test/lang/extensions/SnapshotFileItem.java
@@ -82,4 +82,5 @@ public class SnapshotFileItem {
 		return prettyJson;
 	}
 
+
 }

--- a/src/main/java/com/askimed/nf/test/util/ObjectUtil.java
+++ b/src/main/java/com/askimed/nf/test/util/ObjectUtil.java
@@ -1,0 +1,41 @@
+package com.askimed.nf.test.util;
+
+import com.askimed.nf.test.lang.extensions.SnapshotFile;
+import groovy.json.JsonGenerator;
+import groovy.json.JsonOutput;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class ObjectUtil {
+
+    public static String getMd5(Object object) {
+        JsonGenerator jsonGenerator = SnapshotFile.createJsonGenerator();
+        String json = jsonGenerator.toJson(object);
+        try {
+            return calculateMD5(JsonOutput.prettyPrint(json));
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public static String calculateMD5(String input) throws NoSuchAlgorithmException {
+        // Get an instance of the MD5 message digest algorithm
+        MessageDigest md = MessageDigest.getInstance("MD5");
+
+        // Update the digest with the input string's bytes
+        md.update(input.getBytes());
+
+        // Get the hash value as an array of bytes
+        byte[] digest = md.digest();
+
+        // Convert the byte array to a hexadecimal string
+        StringBuilder result = new StringBuilder();
+        for (byte b : digest) {
+            result.append(String.format("%02x", b));
+        }
+
+        return result.toString();
+    }
+}

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -298,4 +298,13 @@ public class ProcessTest {
 
 	}
 
+	@Test
+	public void testMd5Snapshots() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/snapshots/md5.nf.test" });
+		assertEquals(0, exitCode);
+
+	}
+
 }

--- a/test-data/process/snapshots/md5.nf.test
+++ b/test-data/process/snapshots/md5.nf.test
@@ -1,0 +1,36 @@
+nextflow_process {
+
+  name "Test process xy"
+
+  script "./process.nf"
+  process "TEST_PROCESS"
+
+  test("Should succeed because two unique snapshots") {
+
+    when {
+      process {
+        """
+        input[0] = "Lukas"
+        """
+      }
+    }
+
+    then {
+
+      def content = [
+        object1: "lukas",
+        object2: 27,
+        object3: [
+            a: "lll",
+            b: [1,2,3,4,5,6]
+        ]
+      ]
+
+      assert process.success
+      assert snapshot(content).match()
+      assert snapshot(content).md5().match("lukas")
+    }
+
+  }
+
+}

--- a/test-data/process/snapshots/md5.nf.test.snap
+++ b/test-data/process/snapshots/md5.nf.test.snap
@@ -1,0 +1,26 @@
+{
+    "Should succeed because two unique snapshots": {
+        "content": [
+            {
+                "object1": "lukas",
+                "object2": 27,
+                "object3": {
+                    "a": "lll",
+                    "b": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6
+                    ]
+                }
+            }
+        ],
+        "timestamp": "2024-01-28T11:41:29.018819"
+    },
+    "lukas": {
+        "content": "a54d97026c5ed6e6a57ccd3a3f5a3cbc",
+        "timestamp": "2024-01-28T11:41:29.025981"
+    }
+}


### PR DESCRIPTION
This PR adds the function `md5()` to snapshots that allow to store the hashsum instead of the content in the snapshot file. This fixes #175.

```
def content = [
  object1: "lukas",
  object2: 27,
  object3: [
      a: "lll",
      b: [1,2,3,4,5,6]
  ]
]

assert snapshot(content).match("snapshot1")
assert snapshot(content).md5().match("snapshot2")
```

Snapshot:

```
{
    "snapshot1": {
        "content": [
            {
                "object1": "lukas",
                "object2": 27,
                "object3": {
                    "a": "lll",
                    "b": [
                        1,
                        2,
                        3,
                        4,
                        5,
                        6
                    ]
                }
            }
        ],
        "timestamp": "2024-01-28T11:41:29.018819"
    },
    "snapshot2": {
        "content": "a54d97026c5ed6e6a57ccd3a3f5a3cbc",
        "timestamp": "2024-01-28T11:41:29.025981"
    }
}
```