### PR TITLE
Delay launchdir init until test execution

### DIFF
--- a/src/main/java/com/askimed/nf/test/core/AbstractTest.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTest.java
@@ -95,17 +95,26 @@ public abstract class AbstractTest implements ITest {
 		return config;
 	}
 
-	@Override
-	public void setup(Config config, File testDirectory) throws IOException {
+	public void defineDirectories(File testDirectory) throws IOException {
 
 		if (testDirectory == null) {
 			throw new IOException("Testcase setup failed: No home directory set");
 		}
 
-		launchDir = initDirectory("Launch Directory", testDirectory, DIRECTORY_TESTS, getHash());
-		metaDir = initDirectory("Meta Directory", launchDir, DIRECTORY_META);
-		outputDir = initDirectory("Output Directory", launchDir, DIRECTORY_OUTPUT);
-		workDir = initDirectory("Working Directory", launchDir, DIRECTORY_WORK);
+		launchDir = constructDirectory(testDirectory, DIRECTORY_TESTS, getHash());
+		metaDir = constructDirectory(launchDir, DIRECTORY_META);
+		outputDir = constructDirectory(launchDir, DIRECTORY_OUTPUT);
+		workDir = constructDirectory(launchDir, DIRECTORY_WORK);
+
+	}
+
+	@Override
+	public void setup(Config config) throws IOException {
+
+		initDirectory("Launch Directory", launchDir);
+		initDirectory("Meta Directory", metaDir);
+		initDirectory("Output Directory", outputDir);
+		initDirectory("Working Directory", workDir);
 		FileStaging[] sharedDirectories = new FileStaging[]{
 				new FileStaging("bin", config != null ? config.getStageMode() : FileStaging.MODE_COPY),
 				new FileStaging("lib",  config != null ? config.getStageMode() : FileStaging.MODE_COPY),
@@ -136,15 +145,17 @@ public abstract class AbstractTest implements ITest {
 		}
 	}
 
-	public File initDirectory(String name, File root, String... childs) throws IOException {
-
+	public File constructDirectory(File root, String... childs) {
 		String path = FileUtil.path(root.getAbsolutePath(), FileUtil.path(childs));
-
 		File directory = new File(path).getAbsoluteFile();
+		return directory;
+	}
+
+	public void initDirectory(String name, File directory) throws IOException {
+
 		try {
 			FileUtil.deleteDirectory(directory);
 			FileUtil.createDirectory(directory);
-			return directory;
 		} catch (Exception e) {
 			throw new IOException(name + " '" + directory + "' could not be deleted or created:\n" + e);
 		}

--- a/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTestSuite.java
@@ -82,13 +82,18 @@ public abstract class AbstractTestSuite implements ITestSuite {
 			Closure closure = namedClosure.closure;
 
 			ITest test = getNewTestInstance(testName);
-			test.setup(config, getHomeDirectory());
+			test.defineDirectories(getHomeDirectory());
 			closure.setDelegate(test);
 			closure.setResolveStrategy(Closure.DELEGATE_ONLY);
 			closure.call();
 			addTest(test);
 		}
 	}
+
+	public void setupTest(ITest test) throws Throwable {
+		test.setup(config);
+	}
+
 
 	protected abstract ITest getNewTestInstance(String name);
 

--- a/src/main/java/com/askimed/nf/test/core/ITest.java
+++ b/src/main/java/com/askimed/nf/test/core/ITest.java
@@ -6,7 +6,9 @@ import com.askimed.nf.test.config.Config;
 
 public interface ITest extends ITaggable {
 
-	public void setup(Config config, File homeDirectory) throws Throwable;
+	public void defineDirectories(File testDirectory) throws Throwable;
+
+	public void setup(Config config) throws Throwable;
 
 	public void execute() throws Throwable;
 

--- a/src/main/java/com/askimed/nf/test/core/ITestSuite.java
+++ b/src/main/java/com/askimed/nf/test/core/ITestSuite.java
@@ -36,4 +36,6 @@ public interface ITestSuite extends ITaggable {
 	
 	public void evalualteTestClosures() throws Throwable;
 
+	public void setupTest(ITest test) throws Throwable;
+
 }

--- a/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
+++ b/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
@@ -199,6 +199,8 @@ public class TestExecutionEngine {
 				log.info("Run test '{}'. type: {}", test, test.getClass().getName());
 				totalTests++;
 
+				testSuite.setupTest(test);
+
 				listener.executionStarted(test);
 				TestExecutionResult result = new TestExecutionResult(test);
 				test.setWithTrace(withTrace);


### PR DESCRIPTION
This change separates the definition of the launch/meta/output/work directory paths from the physical re-initialization of the actual directories on the filesystem. The definition of the paths still happens up front, but the init and the rest of the `setup()` call has been moved down into the test execution engine inner loop. This prevents nf-test from changing the filesystem until the last moment before any given test actually runs. With this change, `nf-test list` or running specified tests no longer deletes the output from other tests. This also conveniently enables running tests in parallel without any extra filesystem isolation or containerization.

Fixes #213
