### PR TITLE
Add `--ci` flag

### DIFF
--- a/docs/docs/cli/test.md
+++ b/docs/docs/cli/test.md
@@ -46,6 +46,11 @@ Writes test results in [JUnit XML format](https://junit.org/) to file, which con
 
 Writes test results in csv file.
 
+#### `--ci`
+
+By default,nf-test automatically stores a new snapshot. When CI mode is activated, nf-test will fail the test instead of storing the snapshot automatically.
+
+
 ### Optimizing Test Execution
 
 #### `--related-tests <files>`

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -71,7 +71,10 @@ public class RunTestsCommand extends AbstractCommand {
 			"--updateSnapshot" }, description = "Use this flag to re-record every snapshot that fails during this test run.", required = false, showDefaultValue = Visibility.ALWAYS)
 	private boolean updateSnapshot = false;
 
-	@Option(names = { "--related-tests", "--relatedTests"}, description = "Finds all related tests for the provided .nf or nf.test files.", required = false, showDefaultValue = Visibility.ALWAYS)
+	@Option(names = { "--ci" }, description = "Activates CI mode. Instead of automatically storing a new snapshot as per usual, it will now fail the test.", required = false, showDefaultValue = Visibility.ALWAYS)
+	private boolean ciMode = false;
+
+	@Option(names = { "--related-tests", "--relatedTests"}, description = "Finds and executes all related tests for the provided .nf or nf.test files.", required = false, showDefaultValue = Visibility.ALWAYS)
 	private boolean findRelatedTests = false;
 
 	@Option(names = { "--follow-dependencies", "--followDependencies"}, description = "Follows all dependencies when related-tests is set.", required = false, showDefaultValue = Visibility.ALWAYS)
@@ -281,6 +284,7 @@ public class RunTestsCommand extends AbstractCommand {
 			engine.setDebug(debug);
 			engine.setUpdateSnapshot(updateSnapshot);
 			engine.setCleanSnapshot(cleanSnapshot);
+			engine.setCIMode(ciMode);
 			engine.addProfile(profile);
 			engine.setDryRun(dryRun);
 			if (withoutTrace) {

--- a/src/main/java/com/askimed/nf/test/core/AbstractTest.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTest.java
@@ -63,6 +63,8 @@ public abstract class AbstractTest implements ITest {
 
 	private boolean updateSnapshot = false;
 
+	private boolean ciMode = false;
+
 	private boolean debug = false;
 
 	private boolean withTrace = true;
@@ -276,8 +278,19 @@ public abstract class AbstractTest implements ITest {
 		this.updateSnapshot = updateSnapshot;
 	}
 
+	@Override
 	public boolean isUpdateSnapshot() {
 		return updateSnapshot;
+	}
+
+	@Override
+	public void setCIMode(boolean ciMode) {
+		this.ciMode = ciMode;
+	}
+
+	@Override
+	public boolean isCIMode() {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/com/askimed/nf/test/core/AbstractTest.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTest.java
@@ -278,7 +278,6 @@ public abstract class AbstractTest implements ITest {
 		this.updateSnapshot = updateSnapshot;
 	}
 
-	@Override
 	public boolean isUpdateSnapshot() {
 		return updateSnapshot;
 	}

--- a/src/main/java/com/askimed/nf/test/core/ITest.java
+++ b/src/main/java/com/askimed/nf/test/core/ITest.java
@@ -30,7 +30,7 @@ public interface ITest extends ITaggable {
 
 	public void setUpdateSnapshot(boolean updateSnapshot);
 
-	public boolean isUpdateSnapshot2();
+	public boolean isUpdateSnapshot();
 
 	public void setCIMode(boolean ciMode);
 

--- a/src/main/java/com/askimed/nf/test/core/ITest.java
+++ b/src/main/java/com/askimed/nf/test/core/ITest.java
@@ -30,6 +30,10 @@ public interface ITest extends ITaggable {
 
 	public void setUpdateSnapshot(boolean updateSnapshot);
 
-	public boolean isUpdateSnapshot();
+	public boolean isUpdateSnapshot2();
+
+	public void setCIMode(boolean ciMode);
+
+	public boolean isCIMode();
 
 }

--- a/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
+++ b/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
@@ -38,6 +38,8 @@ public class TestExecutionEngine {
 
 	private boolean updateSnapshot = false;
 
+	private boolean ciMode = false;
+
 	private boolean cleanSnapshot = false;
 
 	private boolean dryRun = false;
@@ -71,6 +73,13 @@ public class TestExecutionEngine {
 			System.out.println("Warning: every snapshot that fails during this test run is re-record.");
 		}
 		this.updateSnapshot = updateSnapshot;
+	}
+
+	public void setCIMode(boolean ciMode) {
+		if (updateSnapshot) {
+			System.out.println("nf-test runs in CI mode.");
+		}
+		this.ciMode = ciMode;
 	}
 
 	public void setCleanSnapshot(boolean cleanSnapshot) {
@@ -141,6 +150,7 @@ public class TestExecutionEngine {
 				TestExecutionResult result = new TestExecutionResult(test);
 				test.setWithTrace(withTrace);
 				test.setUpdateSnapshot(updateSnapshot);
+				test.setCIMode(ciMode);
 				try {
 
 					// override debug flag from CLI

--- a/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
+++ b/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
@@ -76,7 +76,7 @@ public class TestExecutionEngine {
 	}
 
 	public void setCIMode(boolean ciMode) {
-		if (updateSnapshot) {
+		if (ciMode) {
 			System.out.println("nf-test runs in CI mode.");
 		}
 		this.ciMode = ciMode;

--- a/src/main/java/com/askimed/nf/test/lang/extensions/Snapshot.java
+++ b/src/main/java/com/askimed/nf/test/lang/extensions/Snapshot.java
@@ -43,6 +43,9 @@ public class Snapshot {
 		SnapshotFileItem expected = file.getSnapshot(id);
 		// new snapshot --> create snapshot
 		if (expected == null) {
+			if (test.isCIMode()) {
+				throw new RuntimeException("CI mode activated and snapshot with id '" + id + "not found.");
+			}
 			log.debug("Snapshot '{}' not found.", id);
 			file.createSnapshot(id, actual);
 			file.save();


### PR DESCRIPTION
The `--ci` flag activates the CI mode. Instead of automatically storing a new snapshot as per usual, it will now fail the test if no reference snapshot is available.

his enables tests to fail on GitHub actions when a snapshot file was forgotten to be committed.