### PR TITLE
Add flag to filter dependencies based on test case type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test_mock.nf
 site
 /tests
 /.nf-test.log
+/temp

--- a/docs/docs/cli/test.md
+++ b/docs/docs/cli/test.md
@@ -51,6 +51,11 @@ Writes test results in csv file.
 By default,nf-test automatically stores a new snapshot. When CI mode is activated, nf-test will fail the test instead of storing the snapshot automatically.
 
 
+### `--filter <types>`
+
+Filter test cases by specified types (e.g., module, pipeline, workflow or function). Multiple types can be separated by commas.
+
+
 ### Optimizing Test Execution
 
 #### `--related-tests <files>`

--- a/docs/tutorials/github-actions.md
+++ b/docs/tutorials/github-actions.md
@@ -48,7 +48,7 @@ jobs:
           sudo mv nf-test /usr/local/bin/
 
       - name: Run Tests
-        run: nf-test test
+        run: nf-test test --ci
 ```
 
 ### Explanation:
@@ -57,7 +57,7 @@ jobs:
 2. **Set up JDK 11**: Uses the `actions/setup-java@v2` action to set up Java Development Kit version 11.
 3. **Setup Nextflow**: Uses the `nf-core/setup-nextflow@v1` action to install the latest-edge version of Nextflow.
 4. **Install nf-test**: Downloads and installs nf-test.
-5. **Run Tests**: Runs nf-test without sharding.
+5. **Run Tests**: Runs nf-test with the `--ci` flag. This activates the CI mode. Instead of automatically storing a new snapshot as per usual, it will now fail the test if no reference snapshot is available. This enables tests to fail when a snapshot file was forgotten to be committed.
 
 ## Step 2: Extending to Use Sharding
 
@@ -95,7 +95,7 @@ jobs:
           sudo mv nf-test /usr/local/bin/
 
       - name: Run Tests (Shard ${{ matrix.shard }}/${{ strategy.job-total }})
-        run: nf-test test --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+        run: nf-test test --ci --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 ```
 
 ### Explanation of Sharding:
@@ -141,7 +141,7 @@ jobs:
           sudo mv nf-test /usr/local/bin/
 
       - name: Run Tests (Shard ${{ matrix.shard }}/${{ strategy.job-total }})
-        run: nf-test test --shard ${{ matrix.shard }}/${{ strategy.job-total }} --changed-since HEAD^
+        run: nf-test test --ci --shard ${{ matrix.shard }}/${{ strategy.job-total }} --changed-since HEAD^
 ```
 
 ### Explanation of Changes:
@@ -171,6 +171,16 @@ config {
     - `'test-data/**/*'`: Changes to any files within the `test-data` directory will trigger a full test run.
 
 This configuration ensures that critical changes always result in a comprehensive validation of the pipeline, providing additional confidence in your CI process.
+
+## Step 5: Additional useful Options
+
+The `--filter` flag allows you to selectively run test cases based on their specified types. For example, you can filter tests by module, pipeline, workflow, or function. This is particularly useful when you have a large suite of tests and need to focus on specific areas of functionality. By separating multiple types with commas, you can run a customized subset of tests that match the exact criteria you're interested in, thereby saving time and resources.
+
+The `--related-tests` flag enables you to identify and execute all tests related to the provided `.nf` or `nf.test` files. This is ideal for scenarios where you have made changes to specific files and want to ensure that only the relevant tests are run. You can provide multiple files by separating them with spaces, which makes it easy to manage and test multiple changes at once, ensuring thorough validation of your updates.
+
+When the `--follow-dependencies` flag is set, the nf-test tool will automatically traverse and execute all tests for dependencies related to the files specified with the `--related-tests` flag. This ensures that any interdependent components are also tested, providing comprehensive coverage. This option is particularly useful for complex projects with multiple dependencies, as it bypasses the firewall calculation process and guarantees that all necessary tests are executed.
+
+The `--changed-until` flag allows you to run tests based on changes made up until a specified commit hash or branch name. By default, this parameter uses `HEAD`, but you can specify any commit or branch to target the changes made up to that point. This is particularly useful for validating changes over a specific range of commits, ensuring that all modifications within that period are tested comprehensively.
 
 ## Summary
 

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -13,6 +13,7 @@ import com.askimed.nf.test.core.reports.CsvReportWriter;
 import com.askimed.nf.test.lang.dependencies.Coverage;
 import com.askimed.nf.test.lang.dependencies.DependencyExporter;
 import com.askimed.nf.test.lang.dependencies.DependencyResolver;
+import com.askimed.nf.test.lang.dependencies.IMetaFile;
 import com.askimed.nf.test.util.AnsiText;
 import com.askimed.nf.test.util.GitCommand;
 import org.slf4j.Logger;
@@ -79,6 +80,9 @@ public class RunTestsCommand extends AbstractCommand {
 
 	@Option(names = { "--follow-dependencies", "--followDependencies"}, description = "Follows all dependencies when related-tests is set.", required = false, showDefaultValue = Visibility.ALWAYS)
 	private boolean followDependencies = false;
+
+	@Option(names = { "--filter" }, description =  "Filter test cases by specified types (e.g., module, pipeline, workflow or function). Multiple types can be separated by commas.", required = false, showDefaultValue = Visibility.ALWAYS)
+	private String dependencies = "all";
 
 	@Option(names = { "--only-changed", "--onlyChanged"}, description = "Runs tests only for those files which are modified in the current git repository", required = false, showDefaultValue = Visibility.ALWAYS)
 	private boolean onlyChanged = false;
@@ -188,6 +192,7 @@ public class RunTestsCommand extends AbstractCommand {
 			File baseDir = new File(new File("").getAbsolutePath());
 			DependencyResolver resolver = new DependencyResolver(baseDir);
 			resolver.setFollowingDependencies(followDependencies);
+			resolver.setTargets(IMetaFile.TargetType.parse(dependencies));
 
 			if (onlyChanged || changedSince != null) {
 

--- a/src/main/java/com/askimed/nf/test/lang/dependencies/DependencyGraph.java
+++ b/src/main/java/com/askimed/nf/test/lang/dependencies/DependencyGraph.java
@@ -57,7 +57,6 @@ public class DependencyGraph {
     public void connectDependencies(){
             for (Node node: nodes.values()) {
                 for (String dependency: node.getMetaFile().getDependencies()) {
-                    //addDependency(dependency, node.getFilename());
                     addDependency(dependency, node.getFilename());
                 }
             }

--- a/src/main/java/com/askimed/nf/test/lang/dependencies/IMetaFile.java
+++ b/src/main/java/com/askimed/nf/test/lang/dependencies/IMetaFile.java
@@ -1,6 +1,7 @@
 package com.askimed.nf.test.lang.dependencies;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 
 public interface IMetaFile {
@@ -9,12 +10,32 @@ public interface IMetaFile {
 
     public MetaFileType getType();
 
+    public TargetType getTarget();
+
     public String getFilename();
 
     public void parseDependencies() throws IOException;
 
     public static enum MetaFileType{
         SOURCE_FILE, TEST_FILE, SNAPSHOT_FILE
+    }
+
+    public static enum TargetType{
+        PROCESS, WORKFLOW, PIPELINE, FUNCTION, UNDEFINED;
+
+        public static Set<TargetType> parse(String targets) {
+            Set<TargetType> result = new HashSet<TargetType>();
+            String cleaned = targets.trim().toUpperCase();
+            if (cleaned.isEmpty() || cleaned.equalsIgnoreCase("ALL")) {
+                return result;
+            }
+            for (String target: cleaned.split(",")) {
+                String cleanedTarget = target.trim();
+                result.add(TargetType.valueOf(cleanedTarget));
+            }
+            return result;
+        }
+
     }
 
 }

--- a/src/main/java/com/askimed/nf/test/lang/dependencies/SnapshotFile.java
+++ b/src/main/java/com/askimed/nf/test/lang/dependencies/SnapshotFile.java
@@ -45,4 +45,9 @@ public class SnapshotFile implements  IMetaFile {
         return dependencies;
     }
 
+    @Override
+    public TargetType getTarget() {
+        return TargetType.UNDEFINED;
+    }
+
 }

--- a/src/main/java/com/askimed/nf/test/nextflow/NextflowScript.java
+++ b/src/main/java/com/askimed/nf/test/nextflow/NextflowScript.java
@@ -163,6 +163,11 @@ public class NextflowScript implements IMetaFile {
 
 	}
 
+	@Override
+	public TargetType getTarget() {
+		return TargetType.UNDEFINED;
+	}
+
 	protected static Path resolve(File file, String dependency) {
 		if (dependency.startsWith("./") || dependency.startsWith("../")) {
 			return Paths.get(file.getParentFile().getAbsolutePath()).resolve(dependency);

--- a/src/test/java/com/askimed/nf/test/lang/dependencies/DependencyResolverTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/dependencies/DependencyResolverTest.java
@@ -9,8 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.List;
-import java.util.Vector;
+import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -81,6 +80,82 @@ class DependencyResolverTest {
         Coverage coverage = new Coverage(resolver);
         assertEquals(17, coverage.getAll().getCoveredItems());
         assertEquals(17, coverage.getAll().getItems().size());
+    }
+
+    @Test
+    void findRelatedTestAndFilterDependencies() throws Exception {
+
+        File root = getFetchNgs();
+
+        DependencyResolver resolver = new DependencyResolver(root);
+        resolver.setFollowingDependencies(false);
+
+        resolver.buildGraph();
+        assertEquals(10, resolver.findRelatedTestsByFiles(
+                new File(root, "modules/local/sra_to_samplesheet/main.nf")
+        ).size());
+
+        resolver = new DependencyResolver(root);
+        Set<IMetaFile.TargetType> targets = new HashSet<IMetaFile.TargetType>();
+        targets.add(IMetaFile.TargetType.PROCESS);
+        resolver.setTargets(targets);
+
+        resolver.buildGraph();
+        assertEquals(1, resolver.findRelatedTestsByFiles(
+                new File(root, "modules/local/sra_to_samplesheet/main.nf")
+        ).size());
+
+        resolver = new DependencyResolver(root);
+         targets = new HashSet<IMetaFile.TargetType>();
+        targets.add(IMetaFile.TargetType.PROCESS);
+        targets.add(IMetaFile.TargetType.WORKFLOW);
+        resolver.setTargets(targets);
+
+        resolver.buildGraph();
+        assertEquals(10, resolver.findRelatedTestsByFiles(
+                new File(root, "modules/local/sra_to_samplesheet/main.nf")
+        ).size());
+
+        resolver = new DependencyResolver(root);
+        targets = new HashSet<IMetaFile.TargetType>();
+        targets.add(IMetaFile.TargetType.WORKFLOW);
+        resolver.setTargets(targets);
+
+        resolver.buildGraph();
+        assertEquals(9, resolver.findRelatedTestsByFiles(
+                new File(root, "modules/local/sra_to_samplesheet/main.nf")
+        ).size());
+
+        resolver = new DependencyResolver(root);
+        targets = new HashSet<IMetaFile.TargetType>();
+        targets.add(IMetaFile.TargetType.PIPELINE);
+        resolver.setTargets(targets);
+        resolver.setFollowingDependencies(true);
+        resolver.buildGraph();
+        assertEquals(1, resolver.findRelatedTestsByFiles(
+                new File(root, "modules/local/sra_to_samplesheet/main.nf")
+        ).size());
+
+        resolver = new DependencyResolver(root);
+        targets = new HashSet<IMetaFile.TargetType>();
+        targets.add(IMetaFile.TargetType.PIPELINE);
+        targets.add(IMetaFile.TargetType.WORKFLOW);
+        resolver.setTargets(targets);
+        resolver.setFollowingDependencies(true);
+        resolver.buildGraph();
+        assertEquals(10, resolver.findRelatedTestsByFiles(
+                new File(root, "modules/local/sra_to_samplesheet/main.nf")
+        ).size());
+
+        resolver = new DependencyResolver(root);
+        targets = new HashSet<IMetaFile.TargetType>();
+        targets.add(IMetaFile.TargetType.WORKFLOW);
+        resolver.setTargets(targets);
+        resolver.setFollowingDependencies(true);
+        resolver.buildGraph();
+        assertEquals(9, resolver.findRelatedTestsByFiles(
+                new File(root, "modules/local/sra_to_samplesheet/main.nf")
+        ).size());
     }
 
     @Test

--- a/src/test/java/com/askimed/nf/test/lang/dependencies/IMetaFileTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/dependencies/IMetaFileTest.java
@@ -1,0 +1,31 @@
+package com.askimed.nf.test.lang.dependencies;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IMetaFileTest {
+
+    @Test
+    void parseDependencies() {
+        String input = "workflow,process";
+        Set<IMetaFile.TargetType> targets = new HashSet<IMetaFile.TargetType>();
+        targets.add(IMetaFile.TargetType.WORKFLOW);
+        targets.add(IMetaFile.TargetType.PROCESS);
+        assertEquals(targets , IMetaFile.TargetType.parse(input));
+    }
+
+    @Test
+    void parseDependenciesAll() {
+        String input = "all";
+        Set<IMetaFile.TargetType> targets = new HashSet<IMetaFile.TargetType>();
+        assertEquals(targets , IMetaFile.TargetType.parse(input));
+
+        input = "  ";
+        targets = new HashSet<IMetaFile.TargetType>();
+        assertEquals(targets , IMetaFile.TargetType.parse(input));
+    }
+}


### PR DESCRIPTION
This PR add the `--filter` flag to filter test cases and dependencies based on the type (e.g. workflow,process,pipeline or function). This addresses #196.
