### PR TITLE
feat: add classname attribute to junit xml report

### DIFF
--- a/src/main/java/com/askimed/nf/test/core/reports/XmlReportWriter.java
+++ b/src/main/java/com/askimed/nf/test/core/reports/XmlReportWriter.java
@@ -52,7 +52,7 @@ public class XmlReportWriter extends AbstractTestReportWriter {
 
 				for (TestExecutionResult test : testSuite.getTests()) {
 					writer.writeStartElement("testcase");
-					writer.writeAttribute("classname", testSuite.getTestSuite().getName())
+					writer.writeAttribute("classname", testSuite.getTestSuite().getName());
 					writer.writeAttribute("name", test.getTest().getName());
 					writer.writeAttribute("time", Double.toString(test.getExecutionTimeInSecs()));
 					writer.writeAttribute("status", test.getStatus().toString());

--- a/src/main/java/com/askimed/nf/test/core/reports/XmlReportWriter.java
+++ b/src/main/java/com/askimed/nf/test/core/reports/XmlReportWriter.java
@@ -52,6 +52,7 @@ public class XmlReportWriter extends AbstractTestReportWriter {
 
 				for (TestExecutionResult test : testSuite.getTests()) {
 					writer.writeStartElement("testcase");
+					writer.writeAttribute("classname", testSuite.getTestSuite().getName())
 					writer.writeAttribute("name", test.getTest().getName());
 					writer.writeAttribute("time", Double.toString(test.getExecutionTimeInSecs()));
 					writer.writeAttribute("status", test.getStatus().toString());


### PR DESCRIPTION
This adds the `classname` attribute to the `testcase` elements in the junit xml report. 

Closes #228 