### PR TITLE
Update BinaryFinder to expand ~ to unix location

### DIFF
--- a/src/main/java/com/askimed/nf/test/util/BinaryFinder.java
+++ b/src/main/java/com/askimed/nf/test/util/BinaryFinder.java
@@ -54,11 +54,16 @@ public class BinaryFinder {
 		if (envPath != null && !envPath.isEmpty()) {
 			String[] paths = envPath.split(":");
 			for (String path : paths) {
-				String binary = FileUtil.path(path, name);
-				if (new File(binary).exists()) {
-					location = binary;
-					return this;
-				}
+			    // Handle the tilde expansion
+		            if (path.startsWith("~")) {
+		                path = path.replaceFirst("~", System.getProperty("user.home"));
+		            }
+		
+		            String binary = FileUtil.path(path, name);
+		            if (new File(binary).exists()) {
+		                location = binary;
+		                break; // Stop searching once the binary is found
+		            }
 			}
 		}
 


### PR DESCRIPTION
I was trying to use `nf-test` in one of my machines where Nextflow is installed locally for each user at `~/.local/bin`. The current code wasn't picking up the Nextflow installation. I figured that `~` in paths included in $PATH are not expanded by Java as it is a shell concept. So, I made this change to make this work for me. 