### PR TITLE
Add nf-test plugin cookiecutter template link

### DIFF
--- a/docs/docs/plugins/developing-plugins.md
+++ b/docs/docs/plugins/developing-plugins.md
@@ -4,6 +4,8 @@
 
 The following plugin can be used as a boilerplate: [https://github.com/askimed/nft-fasta](https://github.com/askimed/nft-fasta)
 
+The [nf-test plugin cookiecutter template](https://github.com/nvnieuwk/cookiecutter-nftest-plugin) can also be used to set up the plugin base and immediately start developing.
+
 ## Developing Plugins
 
 A plugin has the possibility:


### PR DESCRIPTION
I created a cookiecutter template to create nf-test plugins. https://github.com/nvnieuwk/cookiecutter-nftest-plugin 
This PR adds a mention of it to the nf-test plugin development docs. 

Feel free to close this PR if you don't think this belongs here :)