### PR TITLE
Add `NFT_JAVA_ARGS` environment variable support for custom JVM options

### DIFF
--- a/files/nf-test
+++ b/files/nf-test
@@ -43,6 +43,11 @@ else
   FILE_PATH_JAR=${APP_HOME}/${APP_JAR}
 fi
 
+JAVA_ARGS="-Xmx10G"
+if [[ "$NFT_JAVA_ARGS" ]]; then
+  JAVA_ARGS="$NFT_JAVA_ARGS"
+fi
+
 export JAVA_PROGRAM_ARGS=`echo "$@"`
 
 if [ "${JAVA_PROGRAM_ARGS}" = "update" ]; then
@@ -50,5 +55,5 @@ if [ "${JAVA_PROGRAM_ARGS}" = "update" ]; then
   cd "${FOLDER}"
   update
 else
-  "${JAVA_CMD}" -Xmx10G -jar "${FILE_PATH_JAR}" "$@"
+  exec ${JAVA_CMD} ${JAVA_ARGS} -jar "${FILE_PATH_JAR}" "$@"
 fi

--- a/files/nf-test
+++ b/files/nf-test
@@ -50,5 +50,5 @@ if [ "${JAVA_PROGRAM_ARGS}" = "update" ]; then
   cd "${FOLDER}"
   update
 else
-  java -Xmx10G -jar "${FILE_PATH_JAR}" "$@"
+  "${JAVA_CMD}" -Xmx10G -jar "${FILE_PATH_JAR}" "$@"
 fi


### PR DESCRIPTION
This PR adds support for setting custom JVM options through a new environment variable `NFT_JAVA_ARGS`.

Example Usage:

```bash
export NFT_JAVA_ARGS="-Xmx1G"
nf_test
```

This PR fixes #251