### PR TITLE
Fix TestSuiteResolver parse path containing "@" symbol

### DIFF
--- a/src/main/java/com/askimed/nf/test/core/TestSuiteResolver.java
+++ b/src/main/java/com/askimed/nf/test/core/TestSuiteResolver.java
@@ -3,6 +3,7 @@ package com.askimed.nf.test.core;
 import com.askimed.nf.test.lang.TestSuiteBuilder;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
 
@@ -26,8 +27,11 @@ public class TestSuiteResolver {
             String testId = null;
             if (script.getAbsolutePath().contains("@")) {
                 String[] tiles = script.getAbsolutePath().split("@");
-                script = new File(tiles[0]);
-                testId = tiles[1];
+                testId = tiles[tiles.length - 1];
+
+                String[] fileParts = Arrays.copyOfRange(tiles, 0, tiles.length - 1);
+                String filePath = String.join("@", fileParts);
+                script = new File(filePath);
             }
             if (!script.exists()) {
                 throw new Exception("Test file '" + script.getAbsolutePath() + "' not found.");

--- a/src/main/java/com/askimed/nf/test/core/TestSuiteResolver.java
+++ b/src/main/java/com/askimed/nf/test/core/TestSuiteResolver.java
@@ -3,7 +3,8 @@ package com.askimed.nf.test.core;
 import com.askimed.nf.test.lang.TestSuiteBuilder;
 
 import java.io.File;
-import java.util.Arrays;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Vector;
 
@@ -25,13 +26,14 @@ public class TestSuiteResolver {
 
         for (File script : scripts) {
             String testId = null;
-            if (script.getAbsolutePath().contains("@")) {
-                String[] tiles = script.getAbsolutePath().split("@");
-                testId = tiles[tiles.length - 1];
+            Path path = Paths.get(script.getAbsolutePath());
+            String fileName = path.getFileName().toString();
 
-                String[] fileParts = Arrays.copyOfRange(tiles, 0, tiles.length - 1);
-                String filePath = String.join("@", fileParts);
-                script = new File(filePath);
+            if (fileName.contains("@")) {
+                String[] tiles = fileName.split("@");
+                String basePath = path.getParent().toString();
+                script = new File(Paths.get(basePath, tiles[0]).toString());
+                testId = tiles[1];
             }
             if (!script.exists()) {
                 throw new Exception("Test file '" + script.getAbsolutePath() + "' not found.");


### PR DESCRIPTION
Fixes #263.

The `TestSuiteResolver.parse` method fails when an "@" symbol is in the path. This is because it splits the script's path on "@" to retrieve test ID without accounting for other "@" symbols elsewhere in the path. I have fixed this by using `java.nio.file.Paths` to split the file name from the base path and check only the file name for an "@" symbol.

Let me know if the addition of a unit test case for this would be useful (e.g. to test the case where `scripts` contains a path with an "@" symbol).