### PR TITLE
Fix hello nf-test training link

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -13,7 +13,7 @@ This page collects videos and blog posts about nf-test created by the community.
 
 This training modules introduces nf-test in a simple and easy to follow-along hello-nextflow style aimed for beginners.
 
-[hello nf-test training module](https://training.nextflow.io/hello_nextflow/05_hello_nf-test/)
+[hello nf-test training module](https://training.nextflow.io/fr/hello_nextflow/08_hello_nf-test/)
 
 ---
 


### PR DESCRIPTION
Smallest of PRs just fixing the link to the hello nf-test training since this is now under 08_*.