### PR TITLE
Update test.md `profile link`

### DIFF
--- a/docs/docs/cli/test.md
+++ b/docs/docs/cli/test.md
@@ -10,7 +10,7 @@ nf-test test [<NEXTFLOW_FILES>|<SCRIPT_FOLDERS>]
 
 #### `--profile <NEXTFLOW_PROFILE>`
 
-To run your test using a specific Nextflow profile, you can use the `--profile` argument. [Learn more](/docs/docs/configuration#managing-profiles).
+To run your test using a specific Nextflow profile, you can use the `--profile` argument. [Learn more](/docs/configuration#managing-profiles).
 
 #### `--dry-run`
 


### PR DESCRIPTION
Link is broken, is currently reffering to 
1. https://www.nf-test.com/docs/docs/configuration#managing-profiles
2. https://www.nf-test.com/docs/configuration#managing-profiles

