### PR TITLE
Fix documentation for `--filter` using `module` instead of `process`

### DIFF
--- a/docs/docs/cli/test.md
+++ b/docs/docs/cli/test.md
@@ -53,7 +53,7 @@ By default,nf-test automatically stores a new snapshot. When CI mode is activate
 
 ### `--filter <types>`
 
-Filter test cases by specified types (e.g., module, pipeline, workflow or function). Multiple types can be separated by commas.
+Filter test cases by specified types (e.g., process, pipeline, workflow or function). Multiple types can be separated by commas.
 
 
 ### Optimizing Test Execution

--- a/docs/tutorials/github-actions.md
+++ b/docs/tutorials/github-actions.md
@@ -174,7 +174,7 @@ This configuration ensures that critical changes always result in a comprehensiv
 
 ## Step 5: Additional useful Options
 
-The `--filter` flag allows you to selectively run test cases based on their specified types. For example, you can filter tests by module, pipeline, workflow, or function. This is particularly useful when you have a large suite of tests and need to focus on specific areas of functionality. By separating multiple types with commas, you can run a customized subset of tests that match the exact criteria you're interested in, thereby saving time and resources.
+The `--filter` flag allows you to selectively run test cases based on their specified types. For example, you can filter tests by process, pipeline, workflow, or function. This is particularly useful when you have a large suite of tests and need to focus on specific areas of functionality. By separating multiple types with commas, you can run a customized subset of tests that match the exact criteria you're interested in, thereby saving time and resources.
 
 The `--related-tests` flag enables you to identify and execute all tests related to the provided `.nf` or `nf.test` files. This is ideal for scenarios where you have made changes to specific files and want to ensure that only the relevant tests are run. You can provide multiple files by separating them with spaces, which makes it easy to manage and test multiple changes at once, ensuring thorough validation of your updates.
 

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -81,7 +81,7 @@ public class RunTestsCommand extends AbstractCommand {
 	@Option(names = { "--follow-dependencies", "--followDependencies"}, description = "Follows all dependencies when related-tests is set.", required = false, showDefaultValue = Visibility.ALWAYS)
 	private boolean followDependencies = false;
 
-	@Option(names = { "--filter" }, description =  "Filter test cases by specified types (e.g., module, pipeline, workflow or function). Multiple types can be separated by commas.", required = false, showDefaultValue = Visibility.ALWAYS)
+	@Option(names = { "--filter" }, description =  "Filter test cases by specified types (e.g., process, pipeline, workflow or function). Multiple types can be separated by commas.", required = false, showDefaultValue = Visibility.ALWAYS)
 	private String dependencies = "all";
 
 	@Option(names = { "--only-changed", "--onlyChanged"}, description = "Runs tests only for those files which are modified in the current git repository", required = false, showDefaultValue = Visibility.ALWAYS)


### PR DESCRIPTION
Currently the documentation lists `module` as a valid option for the `--filter` flag but that is not recognized. From the code it seems that `process` should be used instead. This PR just fixes up the docs by replacing `module` with `process`.