### PR TITLE
Don't execute cleanup on dry run

### DIFF
--- a/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
+++ b/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
@@ -170,7 +170,6 @@ public class TestExecutionEngine {
 					result.setStartTime(System.currentTimeMillis());
 					if (!dryRun) {
 						test.execute();
-						test.cleanup();
 					}
 					result.setStatus(TestExecutionResultStatus.PASSED);
 
@@ -183,6 +182,9 @@ public class TestExecutionEngine {
 					testSuite.setFailedTests(true);
 					failedTests++;
 
+				}
+				if (!dryRun) {
+					test.cleanup();
 				}
 				result.setEndTime(System.currentTimeMillis());
 


### PR DESCRIPTION
Hi, thanks for the fantastic software!

We are running into a small problem with nf-test where we are including the cleanup block in tests. The cleanup block is always executed, which means that exceptions thrown in the block stop the dry run - we are running into this problem with this test (https://github.com/sanger-tol/nf-core-modules/blob/main/modules/sanger-tol/hiccramalign/minimap2align/tests/main.nf.test) where we are using some functions from nft-utils to cleanup a temporary modules library that is initialised in the `setup` block.

This PR just moves the cleanup line into the section that checks if a dry run is being executed, which should side-step the problem. Not sure if this is the optimal way to do this, so happy to discuss :)