### PR TITLE
Add `--no-save` command

### DIFF
--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -150,7 +150,7 @@ public class RunTestsCommand extends AbstractCommand {
 
 	@Option(
 			names = {"--no-save", "--noSave"},
-			description = "Delete test launch directory after successfull run",
+			description = "Delete test launch directory after successful run",
 			required = false,
 			showDefaultValue = Visibility.ALWAYS
 	)

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -140,13 +140,21 @@ public class RunTestsCommand extends AbstractCommand {
 	)
 	private boolean smartTesting = false;
   
-  @Option(
+  	@Option(
 			names = {"--stop-on-first-failure", "--stopOnFirstFailure"},
 			description = "Stop execution immediately after the first test failure",
 			required = false,
 			showDefaultValue = Visibility.ALWAYS
 	)
 	private boolean stopOnFirstFailure = false;
+
+	@Option(
+			names = {"--no-save", "--noSave"},
+			description = "Delete working directory after successfull run",
+			required = false,
+			showDefaultValue = Visibility.ALWAYS
+	)
+	private boolean noSave = false;
 
 	private static Logger log = LoggerFactory.getLogger(RunTestsCommand.class);
 
@@ -306,6 +314,7 @@ public class RunTestsCommand extends AbstractCommand {
 			engine.setCIMode(ciMode);
 			engine.addProfile(profile);
 			engine.setStopOnFirstFailure(stopOnFirstFailure);
+			engine.setNoSave(noSave);
 			engine.setDryRun(dryRun);
 			if (withoutTrace) {
 				engine.setWithTrace(false);

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -150,7 +150,7 @@ public class RunTestsCommand extends AbstractCommand {
 
 	@Option(
 			names = {"--no-save", "--noSave"},
-			description = "Delete working directory after successfull run",
+			description = "Delete test launch directory after successfull run",
 			required = false,
 			showDefaultValue = Visibility.ALWAYS
 	)

--- a/src/main/java/com/askimed/nf/test/core/AbstractTest.java
+++ b/src/main/java/com/askimed/nf/test/core/AbstractTest.java
@@ -96,6 +96,11 @@ public abstract class AbstractTest implements ITest {
 		return config;
 	}
 
+	@Override
+	public File getLaunchDir() {
+		return launchDir;
+	}
+
 	public void defineDirectories(File testDirectory) throws IOException {
 
 		if (testDirectory == null) {

--- a/src/main/java/com/askimed/nf/test/core/ITest.java
+++ b/src/main/java/com/askimed/nf/test/core/ITest.java
@@ -28,6 +28,8 @@ public interface ITest extends ITaggable {
 
 	public ITestSuite getTestSuite();
 
+	public File getLaunchDir();
+
 	public void setWithTrace(boolean withTrace);
 
 	public void setUpdateSnapshot(boolean updateSnapshot);

--- a/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
+++ b/src/main/java/com/askimed/nf/test/core/TestExecutionEngine.java
@@ -46,6 +46,8 @@ public class TestExecutionEngine {
 
 	private boolean stopOnFirstFailure = false;
 
+	private boolean noSave = false;
+
 	private static Logger log = LoggerFactory.getLogger(TestExecutionEngine.class);
 
 	public void setDebug(boolean debug) {
@@ -98,6 +100,10 @@ public class TestExecutionEngine {
 
 	public void setStopOnFirstFailure(boolean stopOnFirstFailure) {
 		this.stopOnFirstFailure = stopOnFirstFailure;
+	}
+
+	public void setNoSave(boolean noSave) {
+		this.noSave = noSave;
 	}
 
 	public int execute() throws Throwable {
@@ -184,6 +190,22 @@ public class TestExecutionEngine {
 
 				}
 				test.cleanup();
+
+				if (noSave 
+					&& result.getStatus() == TestExecutionResultStatus.PASSED
+					&& !debug
+				) {
+					try {
+						File launchDir = test.getLaunchDir();
+						if (launchDir != null && launchDir.exists()) {
+							log.info("Deleting launch directory due to --no-save: {}", launchDir);
+							FileUtil.deleteDirectory(launchDir);
+						}
+					} catch (Exception e) {
+						log.warn("Failed to delete launch directory for test '{}': {}", test, e.getMessage());
+					}
+				}
+
 				result.setEndTime(System.currentTimeMillis());
 
 				log.info("Test '{}' finished. status: {}", result.getTest(), result.getStatus(), result.getThrowable());

--- a/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/ProcessTest.java
@@ -46,6 +46,42 @@ public class ProcessTest {
 		int exitCode = app.run(new String[] { "test", "test-data/process/example/test1.nf.test" });
 		assertEquals(0, exitCode);
 
+		File testsRoot = new File(".nf-test/tests");
+		File[] testDirs = testsRoot.listFiles(File::isDirectory);
+		assertNotNull(testDirs, "Could not list test directories");
+
+		assertTrue(
+			testDirs.length == 5,
+			"Expected test directories to exist without --no-save"
+		);
+
+		for (File testDir : testDirs) {
+			File workDir = new File(testDir, "work");
+			assertTrue(
+				workDir.exists(),
+				"Launch and Work directory should exist without --no-save"
+			);
+		}
+
+	}
+
+	@Test
+	public void testExampleNoSaveDeletesLaunchDir() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/example/test1.nf.test", "--no-save" });
+		assertEquals(0, exitCode);
+
+		File testsRoot = new File(".nf-test/tests");
+		File[] testDirs = testsRoot.listFiles(File::isDirectory);
+		assertNotNull(testDirs, "Could not list test directories");
+
+		assertEquals(
+			0,
+			testDirs.length,
+			"Expected all test directories to be deleted with --no-save"
+		);
+
 	}
 
 	/*
@@ -122,6 +158,33 @@ public class ProcessTest {
 		App app = new App();
 		int exitCode = app.run(new String[] { "test", "test-data/process/default/test_process_failed.nf.test" });
 		assertEquals(1, exitCode);
+
+	}
+
+	@Test
+	public void testScriptFailedKeepsWorkDirWithNoSave() throws Exception {
+
+		App app = new App();
+		int exitCode = app.run(new String[] { "test", "test-data/process/default/test_process_failed.nf.test", "--no-save" });
+		assertEquals(1, exitCode);
+
+		File testsRoot = new File(".nf-test/tests");
+		File[] testDirs = testsRoot.listFiles(File::isDirectory);
+		assertNotNull(testDirs, "Could not list test directories");
+
+		assertTrue(
+			testDirs.length == 1,
+			"Expected test directories to exist without --no-save"
+		);
+
+		for (File testDir : testDirs) {
+			File workDir = new File(testDir, "work");
+
+			assertTrue(
+				workDir.exists(),
+				"Launch and Work directory should still exist with --no-save if process failed"
+			);
+		}
 
 	}
 

--- a/src/test/java/com/askimed/nf/test/lang/WorkflowTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/WorkflowTest.java
@@ -207,6 +207,12 @@ public class WorkflowTest {
 
 		File testsRoot = new File(".nf-test/tests");
 		File[] testDirs = testsRoot.listFiles(File::isDirectory);
+		assertNotNull(testDirs, "Could not list test directories");
+
+		assertTrue(
+			testDirs.length == 1,
+			"Expected test directories to exist without --no-save"
+		);
 
 		for (File testDir : testDirs) {
 			File workDir = new File(testDir, "work");
@@ -236,8 +242,6 @@ public class WorkflowTest {
 
 		// Locate .nf-test directory
 		File nfTestDir = new File(".nf-test/tests");
-
-		// There should be NO remaining test directories inside
 		File[] remaining = nfTestDir.listFiles(file -> file.isDirectory());
 
 		assertNotNull(remaining, "Could not list test directories");

--- a/src/test/java/com/askimed/nf/test/lang/WorkflowTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/WorkflowTest.java
@@ -50,7 +50,7 @@ public class WorkflowTest {
 		int exitCode = app.run(new String[] { "test", "test-data/workflow/unnamed/trial.unnamed.nf.test" });
 		assertEquals(0, exitCode);
 
-	}Expected test directories to exist without --no-save
+	}
 
 	@Test
 	public void testWorkflowAndSnapshot() throws Exception {

--- a/src/test/java/com/askimed/nf/test/lang/WorkflowTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/WorkflowTest.java
@@ -50,7 +50,7 @@ public class WorkflowTest {
 		int exitCode = app.run(new String[] { "test", "test-data/workflow/unnamed/trial.unnamed.nf.test" });
 		assertEquals(0, exitCode);
 
-	}
+	}Expected test directories to exist without --no-save
 
 	@Test
 	public void testWorkflowAndSnapshot() throws Exception {
@@ -210,7 +210,7 @@ public class WorkflowTest {
 		assertNotNull(testDirs, "Could not list test directories");
 
 		assertTrue(
-			testDirs.length == 1,
+			testDirs.length > 0,
 			"Expected test directories to exist without --no-save"
 		);
 

--- a/src/test/java/com/askimed/nf/test/lang/WorkflowTest.java
+++ b/src/test/java/com/askimed/nf/test/lang/WorkflowTest.java
@@ -1,6 +1,6 @@
 package com.askimed.nf.test.lang;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -191,6 +191,62 @@ public class WorkflowTest {
 		int exitCode = app.run(new String[] { "test", "test-data/workflow/regex/workflow.nf.test" });
 		assertEquals(0, exitCode);
 
+	}
+
+	@Test
+	public void testWorkflowKeepsLaunchDirByDefault() throws Exception {
+
+		App app = new App();
+
+		int exitCode = app.run(new String[] {
+			"test",
+			"test-data/workflow/regex/workflow.nf.test"
+		});
+
+		assertEquals(0, exitCode);
+
+		File testsRoot = new File(".nf-test/tests");
+		File[] testDirs = testsRoot.listFiles(File::isDirectory);
+
+		for (File testDir : testDirs) {
+			File workDir = new File(testDir, "work");
+
+			assertTrue(
+				workDir.exists(),
+				"Launch and Work directory should exist without --no-save"
+			);
+		}
+	}
+
+	@Test
+	public void testWorkflowNoSaveDeletesLaunchDir() throws Exception {
+
+		App app = new App();
+
+		String testPath = "test-data/workflow/regex/workflow.nf.test";
+
+		// Run test with --no-save
+		int exitCode = app.run(new String[] {
+			"test",
+			testPath,
+			"--no-save"
+		});
+
+		assertEquals(0, exitCode);
+
+		// Locate .nf-test directory
+		File nfTestDir = new File(".nf-test/tests");
+
+		// There should be NO remaining test directories inside
+		File[] remaining = nfTestDir.listFiles(file -> file.isDirectory());
+
+		assertNotNull(remaining, "Could not list test directories");
+
+		assertEquals(
+			0,
+			remaining.length,
+			"Expected no test directories to remain when --no-save is enabled"
+		);
 	}
 
 	@Test


### PR DESCRIPTION
This PR introduce the `--no-save` flag for the `test` subcommand.
When a test is successfully ran, the launch directory is deleted to save disk space.

This should be particularly useful for small machine like github action runner.

Closes #298
Closes #315