### PR TITLE
Add exclude tags/tag query option

### DIFF
--- a/docs/docs/cli/test.md
+++ b/docs/docs/cli/test.md
@@ -26,7 +26,17 @@ The Linux tool `procps` is required to run Nextflow tracing. In case your contai
 
 #### `--tag <tag>`
 
-Execute only tests with the provided tag. Multiple tags can be used and have to be separated by commas (e.g. `tag1,tag2`).
+Execute only tests with the provided tag. Multiple tags can be used and have to be separated by commas (e.g. `tag1,tag2`). Tag matching is case-insensitive.
+
+#### `--exclude-tag <tag>`
+
+Don't execute tests with the provided tag. Multiple tags can be used and have to be separated by commas (e.g. `tag1,tag2`). `--exclude-tag` can be used with `--tag` and the exclusion will supersede the inclusion. Tag matching is case-insensitive.
+
+e.g. For `--tag tag1 --exclude-tag tag2` then all tests with `tag1` will be run _except_ those also having `tag2`.
+
+#### `--tag-query <query>`
+
+Use a complex query based on tags to select the tests to run. A simple query-language is supported with negation `!`, and `&&`, and or `||`. As with `--tag` and `--exclude-tag` the tag matching is case insensitive. This option is mutually exclusive to `--tag` and `--exclude-tag`.
 
 #### `--stop-on-first-failure`
 
@@ -62,7 +72,6 @@ Runs in smart testing mode (equivalent to --ci --changed-since HEAD^).
 
 Filter test cases by specified types (e.g., process, pipeline, workflow or function). Multiple types can be separated by commas.
 
-
 ### Optimizing Test Execution
 
 #### `--related-tests <files>`
@@ -94,16 +103,18 @@ This parameter initiates the execution of tests related to changes made until th
 Enables the export of the dependency graph as a dot file.
 The dot file format is commonly used for representing graphs in graphviz and other related software.
 
-### Sharding 
+### Sharding
 
 This parameter allows users to divide the execution workload into manageable chunks, which can be useful for
 parallel or distributed processing.
 
 #### `--shard <shard>`
+
 Splits the execution into arbitrary chunks defined by the format `i/n`, where `i` denotes the index of the current
 chunk and `n` represents the total number of chunks. For instance, `2/5` executes the second chunk out of five.
 
 #### `--shard-strategy <strategy>`
+
 Description: Specifies the strategy used to build shards when the `--shard` parameter is utilized.
 Accepted values are `round-robin` or `none.`. This parameter determines the method employed to distribute workload
 chunks among available resources. With the round-robin strategy, shards are distributed evenly among resources in
@@ -143,16 +154,16 @@ user to manage the assignment of shards. Default value is `round-robin`.
   ```
   nf-test test --related-tests modules/module_a.nf modules/module_b.nf
   ```
-  
+
 - If your project is a Git directory and you have modified files, you can run tests only for these changed files by
-using the following command:
+  using the following command:
 
   ```
   nf-test test --only-changed
   ```
-  
+
 - If you want to test all changes made between the current state of the repository and the last commit,
-you can use the following command:
+  you can use the following command:
 
   ```
   nf-test test --changed-since HEAD^
@@ -161,5 +172,5 @@ you can use the following command:
 - Run only the second of four shards:
 
   ```
-  nf-test test --shard 2/4 
+  nf-test test --shard 2/4
   ```

--- a/docs/docs/running-tests.md
+++ b/docs/docs/running-tests.md
@@ -83,6 +83,35 @@ Adding an explicit inclusion will still not cause `test1` to run
 nf-test test --tag tag3 --exclude-tag tag2  # collects test2
 ```
 
+#### Complex tag queries
+
+The `--tag-query` option allows the user to construct a complex query to select specific to run tests. This parameter is mutually exclusive to the `--tag` and `--exclude-tag` options.
+
+The query language supports the following operators in order of precedence:
+
+- `!`: `NOT`
+- `&&`: `AND`
+- `||`: `OR`
+
+Parentheses can be used to group conditions.
+Tags with spaces (normally test names used as a tag) can be escaped with `'` or `""`
+
+e.g.
+
+```
+# Match all tests with tag1 + tag2 OR with tag3
+--tag-query "(tag1 && tag2) || tag3"
+
+# Match all tests with tag3 OR without tag4
+--tag-query "tag3 || !tag4"
+
+# Match tests called 'complex test' AND tag1
+--tag-query "'complex test' && tag1"
+
+# Match everything that does not have tag1 OR tag2
+--tag-query "!(tag1 || tag2)"
+```
+
 ## Create a TAP output
 
 To run all tests and create a `report.tap` [file](https://testanything.org/), use the following command.

--- a/docs/docs/running-tests.md
+++ b/docs/docs/running-tests.md
@@ -10,7 +10,7 @@ nf-test test
 
 ## Execute specific tests
 
-You can also specify a list of tests, which should be executed. 
+You can also specify a list of tests, which should be executed.
 
 ```
 nf-test test tests/modules/local/salmon_index.nf.test tests/modules/bwa_index.nf.test
@@ -18,9 +18,11 @@ nf-test test tests/modules/local/salmon_index.nf.test tests/modules/bwa_index.nf
 nf-test test tests/modules tests/modules/bwa_index.nf.test
 ```
 
-## Tag tests 
+## Tag tests
 
 nf-test provides a simple tagging mechanism that allows to execute tests by name or by tag.
+
+#### Inclusion by tag
 
 Tags can be defined for each testsuite or for each testcase using the new `tag` directive:
 
@@ -29,17 +31,17 @@ nextflow_process {
 
 	name "suite 1"
 	tag "tag1"
-	
+
 	test("test 1") {
 		tag "tag2"
-		tag "tag3"	 
+		tag "tag3"
 		...
 	}
-	
+
 	test("test 2") {
-	
+
 		tag "tag4"
-		tag "tag5"	 
+		tag "tag5"
 		...
 
 	}
@@ -52,7 +54,7 @@ For example, to execute all tests with `tag2` use the following command.
 nf-test test --tag tag2  # collects test1
 ```
 
-Names are automatically added to tags. This enables to execute suits or tests directly. 
+Names are automatically added to tags. This enables to execute suits or tests directly.
 
 ```
 nf-test test --tag "suite 1"  # collects test1 and test2
@@ -65,6 +67,22 @@ nf-test test --tag tag3,tag4  # collects test1 and test2
 nf-test test --tag TAG3,TAG4  # collects test1 and test2
 ```
 
+#### Exclusion by tag
+
+The `--exclude-tag` option allows the user to supply a list of tags which when matched exclude the test from running. It operates as the direct inverse of `--tag`. Exclusion takes precedence over inclusion.
+
+For example, to execute all tests without `tag2` use the following command.
+
+```
+nf-test test --exclude-tag tag2  # collects test2
+```
+
+Adding an explicit inclusion will still not cause `test1` to run
+
+```
+nf-test test --tag tag3 --exclude-tag tag2  # collects test2
+```
+
 ## Create a TAP output
 
 To run all tests and create a `report.tap` [file](https://testanything.org/), use the following command.
@@ -72,15 +90,11 @@ To run all tests and create a `report.tap` [file](https://testanything.org/), us
 ```
 nf-test test --tap report.tap
 ```
-    
 
 ## Run test by its hash value
 
-To run a specific test using its hash, the following command can be used. The hash value is generated during its first execution. 
+To run a specific test using its hash, the following command can be used. The hash value is generated during its first execution.
 
 ```
 nf-test test tests/main.nf.test@d41119e4
 ```
-
-
-

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -9,6 +9,8 @@ import java.util.Vector;
 import java.util.function.Consumer;
 
 import com.askimed.nf.test.core.*;
+import com.askimed.nf.test.core.tagquery.TagQueryParseException;
+import com.askimed.nf.test.core.tagquery.TagQueryParser;
 import com.askimed.nf.test.core.reports.CsvReportWriter;
 import com.askimed.nf.test.lang.dependencies.Coverage;
 import com.askimed.nf.test.lang.dependencies.DependencyExporter;
@@ -135,6 +137,10 @@ public class RunTestsCommand extends AbstractCommand {
 	@Option(names = {
 			"--exclude-tag" }, split = ",", description = "Exclude tests with this tag", required = false, showDefaultValue = Visibility.ALWAYS)
 	private List<String> excludeTags = new Vector<String>();
+
+	@Option(names = {
+			"--tag-query" }, description = "Filter tests using a boolean tag expression (e.g. '(!tag1 && tag2) || tag3')", required = false)
+	private String tagQuery = null;
 
 	@Option(
 			names = { "--smart-testing", "--smartTesting" },
@@ -281,7 +287,22 @@ public class RunTestsCommand extends AbstractCommand {
 			environment.setPluginManager(manager);
 
 			TestSuiteResolver testSuiteResolver = new TestSuiteResolver(environment);
-			List<ITestSuite> testSuits = testSuiteResolver.parse(scripts, new TagQuery(tags, excludeTags));
+			TagQuery query;
+			if (tagQuery != null) {
+				if (!tags.isEmpty() || !excludeTags.isEmpty()) {
+					System.out.println(AnsiColors.red("Error: --tag-query cannot be combined with --tag or --exclude-tag"));
+					return 1;
+				}
+				try {
+					query = new TagQuery(TagQueryParser.parse(tagQuery));
+				} catch (TagQueryParseException e) {
+					System.out.println(AnsiColors.red("Error: " + e.getMessage()));
+					return 1;
+				}
+			} else {
+				query = new TagQuery(tags, excludeTags);
+			}
+			List<ITestSuite> testSuits = testSuiteResolver.parse(scripts, query);
 
 			testSuits.sort(TestSuiteSorter.getDefault());
 			if (shard != null && !testSuits.isEmpty()) {

--- a/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
+++ b/src/main/java/com/askimed/nf/test/commands/RunTestsCommand.java
@@ -132,6 +132,10 @@ public class RunTestsCommand extends AbstractCommand {
 			"--tag" }, split = ",", description = "Execute only tests with this tag", required = false, showDefaultValue = Visibility.ALWAYS)
 	private List<String> tags = new Vector<String>();
 
+	@Option(names = {
+			"--exclude-tag" }, split = ",", description = "Exclude tests with this tag", required = false, showDefaultValue = Visibility.ALWAYS)
+	private List<String> excludeTags = new Vector<String>();
+
 	@Option(
 			names = { "--smart-testing", "--smartTesting" },
 			description = "Runs in smart testing mode (equivalent to --ci --changed-since HEAD^).",
@@ -277,7 +281,7 @@ public class RunTestsCommand extends AbstractCommand {
 			environment.setPluginManager(manager);
 
 			TestSuiteResolver testSuiteResolver = new TestSuiteResolver(environment);
-			List<ITestSuite> testSuits = testSuiteResolver.parse(scripts, new TagQuery(tags));
+			List<ITestSuite> testSuits = testSuiteResolver.parse(scripts, new TagQuery(tags, excludeTags));
 
 			testSuits.sort(TestSuiteSorter.getDefault());
 			if (shard != null && !testSuits.isEmpty()) {

--- a/src/main/java/com/askimed/nf/test/core/TagQuery.java
+++ b/src/main/java/com/askimed/nf/test/core/TagQuery.java
@@ -1,5 +1,7 @@
 package com.askimed.nf.test.core;
 
+import com.askimed.nf.test.core.tagquery.TagExpression;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
@@ -9,6 +11,8 @@ public class TagQuery {
 	private List<String> tags = new Vector<String>();
 
 	private List<String> excludeTags = new Vector<String>();
+
+	private TagExpression expression = null;
 
 	public TagQuery() {
 
@@ -23,6 +27,10 @@ public class TagQuery {
 		this.excludeTags = toLowerCase(excludeTags);
 	}
 
+	public TagQuery(TagExpression expression) {
+		this.expression = expression;
+	}
+
 	protected List<String> toLowerCase(List<String> tags) {
 		List<String> result = new Vector<String>();
 		for (String tag : tags) {
@@ -32,6 +40,10 @@ public class TagQuery {
 	}
 
 	public boolean matches(ITaggable taggable) {
+
+		if (expression != null) {
+			return expression.evaluate(taggable);
+		}
 
 		if (isExcluded(taggable)) {
 			return false;

--- a/src/main/java/com/askimed/nf/test/core/TagQuery.java
+++ b/src/main/java/com/askimed/nf/test/core/TagQuery.java
@@ -8,16 +8,19 @@ public class TagQuery {
 
 	private List<String> tags = new Vector<String>();
 
+	private List<String> excludeTags = new Vector<String>();
+
 	public TagQuery() {
 
 	}
 
-	public TagQuery(String... tags) {
-		this.tags = toLowerCase(Arrays.asList(tags));
-	}
-
 	public TagQuery(List<String> tags) {
 		this.tags = toLowerCase(tags);
+	}
+
+	public TagQuery(List<String> tags, List<String> excludeTags) {
+		this.tags = toLowerCase(tags);
+		this.excludeTags = toLowerCase(excludeTags);
 	}
 
 	protected List<String> toLowerCase(List<String> tags) {
@@ -29,6 +32,10 @@ public class TagQuery {
 	}
 
 	public boolean matches(ITaggable taggable) {
+
+		if (isExcluded(taggable)) {
+			return false;
+		}
 
 		if (tags == null || tags.size() == 0) {
 			return true;
@@ -46,6 +53,29 @@ public class TagQuery {
 
 		if (taggable.getParent() != null) {
 			return matches(taggable.getParent());
+		}
+
+		return false;
+	}
+
+	private boolean isExcluded(ITaggable taggable) {
+
+		if (excludeTags == null || excludeTags.isEmpty()) {
+			return false;
+		}
+
+		if (excludeTags.contains(taggable.getName().toLowerCase())) {
+			return true;
+		}
+
+		for (String tag : taggable.getTags()) {
+			if (excludeTags.contains(tag.toLowerCase())) {
+				return true;
+			}
+		}
+
+		if (taggable.getParent() != null) {
+			return isExcluded(taggable.getParent());
 		}
 
 		return false;

--- a/src/main/java/com/askimed/nf/test/core/tagquery/AndNode.java
+++ b/src/main/java/com/askimed/nf/test/core/tagquery/AndNode.java
@@ -1,0 +1,28 @@
+package com.askimed.nf.test.core.tagquery;
+
+import com.askimed.nf.test.core.ITaggable;
+
+public class AndNode implements TagExpression {
+
+    private final TagExpression left;
+    private final TagExpression right;
+
+    public AndNode(TagExpression left, TagExpression right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    public TagExpression getLeft() {
+        return left;
+    }
+
+    public TagExpression getRight() {
+        return right;
+    }
+
+    @Override
+    public boolean evaluate(ITaggable taggable) {
+        return left.evaluate(taggable) && right.evaluate(taggable);
+    }
+
+}

--- a/src/main/java/com/askimed/nf/test/core/tagquery/NotNode.java
+++ b/src/main/java/com/askimed/nf/test/core/tagquery/NotNode.java
@@ -1,0 +1,22 @@
+package com.askimed.nf.test.core.tagquery;
+
+import com.askimed.nf.test.core.ITaggable;
+
+public class NotNode implements TagExpression {
+
+    private final TagExpression operand;
+
+    public NotNode(TagExpression operand) {
+        this.operand = operand;
+    }
+
+    public TagExpression getOperand() {
+        return operand;
+    }
+
+    @Override
+    public boolean evaluate(ITaggable taggable) {
+        return !operand.evaluate(taggable);
+    }
+
+}

--- a/src/main/java/com/askimed/nf/test/core/tagquery/OrNode.java
+++ b/src/main/java/com/askimed/nf/test/core/tagquery/OrNode.java
@@ -1,0 +1,28 @@
+package com.askimed.nf.test.core.tagquery;
+
+import com.askimed.nf.test.core.ITaggable;
+
+public class OrNode implements TagExpression {
+
+    private final TagExpression left;
+    private final TagExpression right;
+
+    public OrNode(TagExpression left, TagExpression right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    public TagExpression getLeft() {
+        return left;
+    }
+
+    public TagExpression getRight() {
+        return right;
+    }
+
+    @Override
+    public boolean evaluate(ITaggable taggable) {
+        return left.evaluate(taggable) || right.evaluate(taggable);
+    }
+
+}

--- a/src/main/java/com/askimed/nf/test/core/tagquery/TagExpression.java
+++ b/src/main/java/com/askimed/nf/test/core/tagquery/TagExpression.java
@@ -1,0 +1,9 @@
+package com.askimed.nf.test.core.tagquery;
+
+import com.askimed.nf.test.core.ITaggable;
+
+public interface TagExpression {
+
+    boolean evaluate(ITaggable taggable);
+
+}

--- a/src/main/java/com/askimed/nf/test/core/tagquery/TagNode.java
+++ b/src/main/java/com/askimed/nf/test/core/tagquery/TagNode.java
@@ -1,0 +1,37 @@
+package com.askimed.nf.test.core.tagquery;
+
+import com.askimed.nf.test.core.ITaggable;
+
+public class TagNode implements TagExpression {
+
+    private final String tag;
+
+    public TagNode(String tag) {
+        this.tag = tag.toLowerCase();
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    @Override
+    public boolean evaluate(ITaggable taggable) {
+        return matches(taggable);
+    }
+
+    private boolean matches(ITaggable taggable) {
+        if (tag.equals(taggable.getName().toLowerCase())) {
+            return true;
+        }
+        for (String t : taggable.getTags()) {
+            if (tag.equals(t.toLowerCase())) {
+                return true;
+            }
+        }
+        if (taggable.getParent() != null) {
+            return matches(taggable.getParent());
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/askimed/nf/test/core/tagquery/TagQueryParseException.java
+++ b/src/main/java/com/askimed/nf/test/core/tagquery/TagQueryParseException.java
@@ -1,0 +1,29 @@
+package com.askimed.nf.test.core.tagquery;
+
+public class TagQueryParseException extends RuntimeException {
+
+    private final String query;
+    private final int position;
+
+    public TagQueryParseException(String query, int position, String message) {
+        super(format(query, position, message));
+        this.query = query;
+        this.position = position;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    private static String format(String query, int position, String message) {
+        int clampedPos = Math.min(Math.max(position, 0), query.length());
+        String prefix = "Invalid tag query: ";
+        String pointer = " ".repeat(prefix.length() + clampedPos) + "^";
+        return String.format("%s%s%n%s%n%s", prefix, query, pointer, message);
+    }
+
+}

--- a/src/main/java/com/askimed/nf/test/core/tagquery/TagQueryParser.java
+++ b/src/main/java/com/askimed/nf/test/core/tagquery/TagQueryParser.java
@@ -1,0 +1,176 @@
+package com.askimed.nf.test.core.tagquery;
+
+public class TagQueryParser {
+
+    private enum TokenType {
+        LPAREN, RPAREN, AND, OR, NOT, TAG, EOF
+    }
+
+    private static class Token {
+        final TokenType type;
+        final String value;
+        final int pos;
+
+        Token(TokenType type, String value, int pos) {
+            this.type = type;
+            this.value = value;
+            this.pos = pos;
+        }
+    }
+
+    private final String input;
+    private int pos;
+    private Token lookahead;
+
+    private TagQueryParser(String input) {
+        this.input = input;
+        this.pos = 0;
+        this.lookahead = nextToken();
+    }
+
+    public static TagExpression parse(String input) {
+        if (input == null || input.trim().isEmpty()) {
+            throw new IllegalArgumentException("Tag query must not be empty");
+        }
+        String trimmed = input.trim();
+        TagQueryParser parser = new TagQueryParser(trimmed);
+        TagExpression expr = parser.parseOrExpr();
+        if (parser.lookahead.type != TokenType.EOF) {
+            throw new TagQueryParseException(trimmed, parser.lookahead.pos,
+                    "Unexpected token: '" + parser.lookahead.value + "'");
+        }
+        return expr;
+    }
+
+    // or_expr := and_expr ('||' and_expr)*
+    private TagExpression parseOrExpr() {
+        TagExpression left = parseAndExpr();
+        while (lookahead.type == TokenType.OR) {
+            consume(TokenType.OR);
+            TagExpression right = parseAndExpr();
+            left = new OrNode(left, right);
+        }
+        return left;
+    }
+
+    // and_expr := not_expr ('&&' not_expr)*
+    private TagExpression parseAndExpr() {
+        TagExpression left = parseNotExpr();
+        while (lookahead.type == TokenType.AND) {
+            consume(TokenType.AND);
+            TagExpression right = parseNotExpr();
+            left = new AndNode(left, right);
+        }
+        return left;
+    }
+
+    // not_expr := '!' not_expr | primary
+    private TagExpression parseNotExpr() {
+        if (lookahead.type == TokenType.NOT) {
+            consume(TokenType.NOT);
+            return new NotNode(parseNotExpr());
+        }
+        return parsePrimary();
+    }
+
+    // primary := '(' expr ')' | tag
+    private TagExpression parsePrimary() {
+        if (lookahead.type == TokenType.LPAREN) {
+            int openPos = lookahead.pos;
+            consume(TokenType.LPAREN);
+            TagExpression expr = parseOrExpr();
+            if (lookahead.type != TokenType.RPAREN) {
+                String got = lookahead.type == TokenType.EOF
+                        ? "reached end of input"
+                        : "got '" + lookahead.value + "'";
+                throw new TagQueryParseException(input, openPos,
+                        "Expected ')' to close '(' but " + got);
+            }
+            consume(TokenType.RPAREN);
+            return expr;
+        }
+        if (lookahead.type == TokenType.TAG) {
+            String tag = lookahead.value;
+            consume(TokenType.TAG);
+            return new TagNode(tag);
+        }
+        String got = lookahead.type == TokenType.EOF
+                ? "reached end of input"
+                : "got '" + lookahead.value + "'";
+        throw new TagQueryParseException(input, lookahead.pos,
+                "Expected a tag or '(' but " + got);
+    }
+
+    private void consume(TokenType expected) {
+        // Only called after confirming lookahead.type matches — should never throw
+        lookahead = nextToken();
+    }
+
+    private Token nextToken() {
+        while (pos < input.length() && Character.isWhitespace(input.charAt(pos))) {
+            pos++;
+        }
+
+        if (pos >= input.length()) {
+            return new Token(TokenType.EOF, "", pos);
+        }
+
+        int tokenStart = pos;
+        char c = input.charAt(pos);
+
+        switch (c) {
+            case '(':
+                pos++;
+                return new Token(TokenType.LPAREN, "(", tokenStart);
+            case ')':
+                pos++;
+                return new Token(TokenType.RPAREN, ")", tokenStart);
+            case '!':
+                pos++;
+                return new Token(TokenType.NOT, "!", tokenStart);
+            case '&':
+                if (pos + 1 < input.length() && input.charAt(pos + 1) == '&') {
+                    pos += 2;
+                    return new Token(TokenType.AND, "&&", tokenStart);
+                }
+                throw new TagQueryParseException(input, tokenStart,
+                        "Expected '&&' but got '&' — did you mean '&&'?");
+            case '|':
+                if (pos + 1 < input.length() && input.charAt(pos + 1) == '|') {
+                    pos += 2;
+                    return new Token(TokenType.OR, "||", tokenStart);
+                }
+                throw new TagQueryParseException(input, tokenStart,
+                        "Expected '||' but got '|' — did you mean '||'?");
+            case '"':
+            case '\'': {
+                char quote = c;
+                pos++;
+                StringBuilder sb = new StringBuilder();
+                while (pos < input.length() && input.charAt(pos) != quote) {
+                    sb.append(input.charAt(pos++));
+                }
+                if (pos >= input.length()) {
+                    throw new TagQueryParseException(input, tokenStart,
+                            "Unterminated string literal — missing closing " + quote);
+                }
+                pos++;
+                return new Token(TokenType.TAG, sb.toString(), tokenStart);
+            }
+            default:
+                if (Character.isLetterOrDigit(c) || c == '_' || c == '-') {
+                    StringBuilder sb = new StringBuilder();
+                    while (pos < input.length() &&
+                            (Character.isLetterOrDigit(input.charAt(pos)) ||
+                                    input.charAt(pos) == '_' ||
+                                    input.charAt(pos) == '-')) {
+                        sb.append(input.charAt(pos++));
+                    }
+                    return new Token(TokenType.TAG, sb.toString(), tokenStart);
+                }
+                throw new TagQueryParseException(input, tokenStart,
+                        "Unexpected character '" + c + "'");
+        }
+    }
+
+}

--- a/src/test/java/com/askimed/nf/test/core/TestSuiteResolverTest.java
+++ b/src/test/java/com/askimed/nf/test/core/TestSuiteResolverTest.java
@@ -25,7 +25,7 @@ public class TestSuiteResolverTest {
 	@Test
 	public void executeTestByName() throws Throwable {
 
-		TagQuery query = new TagQuery("test 1");
+		TagQuery query = new TagQuery(List.of("test 1"));
 		List<String> tests = collectTests(query);
 		Assertions.assertEquals(1, tests.size());
 		Assertions.assertTrue(tests.contains("test 1"));
@@ -62,7 +62,7 @@ public class TestSuiteResolverTest {
 	@Test
 	public void executeTestSuiteByName() throws Throwable {
 		{
-			TagQuery query = new TagQuery("suite 1");
+			TagQuery query = new TagQuery(List.of("suite 1"));
 			List<String> tests = collectTests(query);
 			Assertions.assertEquals(2, tests.size());
 			Assertions.assertTrue(tests.contains("test 1"));
@@ -70,7 +70,7 @@ public class TestSuiteResolverTest {
 		}
 
 		{
-			TagQuery query = new TagQuery("SUITE 1");
+			TagQuery query = new TagQuery(List.of("SUITE 1"));
 			List<String> tests = collectTests(query);
 			Assertions.assertEquals(2, tests.size());
 			Assertions.assertTrue(tests.contains("test 1"));
@@ -81,13 +81,13 @@ public class TestSuiteResolverTest {
 	@Test
 	public void executeTestsByTag() throws Throwable {
 		{
-			TagQuery query = new TagQuery("tag2");
+			TagQuery query = new TagQuery(List.of("tag2"));
 			List<String> tests = collectTests(query);
 			Assertions.assertEquals(1, tests.size());
 			Assertions.assertTrue(tests.contains("test 1"));
 		}
 		{
-			TagQuery query = new TagQuery("TAG2");
+			TagQuery query = new TagQuery(List.of("TAG2"));
 			List<String> tests = collectTests(query);
 			Assertions.assertEquals(1, tests.size());
 			Assertions.assertTrue(tests.contains("test 1"));
@@ -97,7 +97,7 @@ public class TestSuiteResolverTest {
 	@Test
 	public void executeTestsByTagAcrossSuites() throws Throwable {
 
-		TagQuery query = new TagQuery("tag5");
+		TagQuery query = new TagQuery(List.of("tag5"));
 		List<String> tests = collectTests(query);
 		Assertions.assertEquals(2, tests.size());
 		Assertions.assertTrue(tests.contains("test 2"));
@@ -107,7 +107,7 @@ public class TestSuiteResolverTest {
 	@Test
 	public void executeTestsBySuiteTag() throws Throwable {
 
-		TagQuery query = new TagQuery("tag1");
+		TagQuery query = new TagQuery(List.of("tag1"));
 		List<String> tests = collectTests(query);
 		Assertions.assertEquals(2, tests.size());
 		Assertions.assertTrue(tests.contains("test 1"));
@@ -117,10 +117,50 @@ public class TestSuiteResolverTest {
 	@Test
 	public void executeTestsByMultipleTags() throws Throwable {
 
-		TagQuery query = new TagQuery("tag3", "tag4");
+		TagQuery query = new TagQuery(List.of("tag3", "tag4"));
 		List<String> tests = collectTests(query);
 		Assertions.assertEquals(2, tests.size());
 		Assertions.assertTrue(tests.contains("test 1"));
+		Assertions.assertTrue(tests.contains("test 2"));
+	}
+
+	@Test
+	public void excludeTestsByTag() throws Throwable {
+
+		TagQuery query = new TagQuery(List.of(), List.of("tag2"));
+		List<String> tests = collectTests(query);
+		Assertions.assertEquals(2, tests.size());
+		Assertions.assertFalse(tests.contains("test 1"));
+		Assertions.assertTrue(tests.contains("test 2"));
+		Assertions.assertTrue(tests.contains("test 3"));
+	}
+
+	@Test
+	public void excludeTestsBySuiteTag() throws Throwable {
+
+		TagQuery query = new TagQuery(List.of(), List.of("tag1"));
+		List<String> tests = collectTests(query);
+		Assertions.assertEquals(1, tests.size());
+		Assertions.assertTrue(tests.contains("test 3"));
+	}
+
+	@Test
+	public void excludeTestsByName() throws Throwable {
+
+		TagQuery query = new TagQuery(List.of(), List.of("test 1"));
+		List<String> tests = collectTests(query);
+		Assertions.assertEquals(2, tests.size());
+		Assertions.assertFalse(tests.contains("test 1"));
+		Assertions.assertTrue(tests.contains("test 2"));
+		Assertions.assertTrue(tests.contains("test 3"));
+	}
+
+	@Test
+	public void includeAndExcludeTags() throws Throwable {
+
+		TagQuery query = new TagQuery(List.of("tag1"), List.of("tag3"));
+		List<String> tests = collectTests(query);
+		Assertions.assertEquals(1, tests.size());
 		Assertions.assertTrue(tests.contains("test 2"));
 	}
 

--- a/src/test/java/com/askimed/nf/test/core/tagquery/TagQueryParserTest.java
+++ b/src/test/java/com/askimed/nf/test/core/tagquery/TagQueryParserTest.java
@@ -1,0 +1,257 @@
+package com.askimed.nf.test.core.tagquery;
+
+import com.askimed.nf.test.core.ITaggable;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TagQueryParserTest {
+
+    private ITaggable taggable(String name, List<String> tags) {
+        return new ITaggable() {
+            public String getName() { return name; }
+            public List<String> getTags() { return tags; }
+            public ITaggable getParent() { return null; }
+        };
+    }
+
+    private ITaggable taggable(String name, List<String> tags, ITaggable parent) {
+        return new ITaggable() {
+            public String getName() { return name; }
+            public List<String> getTags() { return tags; }
+            public ITaggable getParent() { return parent; }
+        };
+    }
+
+    // --- Parser structure ---
+
+    @Test
+    public void parseSingleTag() {
+        TagExpression expr = TagQueryParser.parse("foo");
+        assertInstanceOf(TagNode.class, expr);
+        assertEquals("foo", ((TagNode) expr).getTag());
+    }
+
+    @Test
+    public void parseDoubleQuotedTag() {
+        TagExpression expr = TagQueryParser.parse("\"suite 1\"");
+        assertInstanceOf(TagNode.class, expr);
+        assertEquals("suite 1", ((TagNode) expr).getTag());
+    }
+
+    @Test
+    public void parseSingleQuotedTag() {
+        TagExpression expr = TagQueryParser.parse("'suite 1'");
+        assertInstanceOf(TagNode.class, expr);
+        assertEquals("suite 1", ((TagNode) expr).getTag());
+    }
+
+    @Test
+    public void parseNotExpr() {
+        TagExpression expr = TagQueryParser.parse("!foo");
+        assertInstanceOf(NotNode.class, expr);
+        assertInstanceOf(TagNode.class, ((NotNode) expr).getOperand());
+    }
+
+    @Test
+    public void parseDoubleNot() {
+        TagExpression expr = TagQueryParser.parse("!!foo");
+        assertInstanceOf(NotNode.class, expr);
+        assertInstanceOf(NotNode.class, ((NotNode) expr).getOperand());
+    }
+
+    @Test
+    public void parseAndExpr() {
+        TagExpression expr = TagQueryParser.parse("foo && bar");
+        assertInstanceOf(AndNode.class, expr);
+        assertInstanceOf(TagNode.class, ((AndNode) expr).getLeft());
+        assertInstanceOf(TagNode.class, ((AndNode) expr).getRight());
+    }
+
+    @Test
+    public void parseOrExpr() {
+        TagExpression expr = TagQueryParser.parse("foo || bar");
+        assertInstanceOf(OrNode.class, expr);
+        assertInstanceOf(TagNode.class, ((OrNode) expr).getLeft());
+        assertInstanceOf(TagNode.class, ((OrNode) expr).getRight());
+    }
+
+    @Test
+    public void andBindsTighterThanOr() {
+        // a || b && c should parse as a || (b && c)
+        TagExpression expr = TagQueryParser.parse("a || b && c");
+        assertInstanceOf(OrNode.class, expr);
+        assertInstanceOf(TagNode.class, ((OrNode) expr).getLeft());
+        assertInstanceOf(AndNode.class, ((OrNode) expr).getRight());
+    }
+
+    @Test
+    public void parenthesesOverridePrecedence() {
+        // (a || b) && c
+        TagExpression expr = TagQueryParser.parse("(a || b) && c");
+        assertInstanceOf(AndNode.class, expr);
+        assertInstanceOf(OrNode.class, ((AndNode) expr).getLeft());
+        assertInstanceOf(TagNode.class, ((AndNode) expr).getRight());
+    }
+
+    @Test
+    public void parseComplexExpr() {
+        // (!foo && bar) || baz
+        TagExpression expr = TagQueryParser.parse("(!foo && bar) || baz");
+        assertInstanceOf(OrNode.class, expr);
+        AndNode and = (AndNode) ((OrNode) expr).getLeft();
+        assertInstanceOf(NotNode.class, and.getLeft());
+        assertInstanceOf(TagNode.class, and.getRight());
+        assertInstanceOf(TagNode.class, ((OrNode) expr).getRight());
+    }
+
+    // --- Evaluation ---
+
+    @Test
+    public void evaluateSingleTag() {
+        TagExpression expr = TagQueryParser.parse("foo");
+        assertTrue(expr.evaluate(taggable("test", List.of("foo", "bar"))));
+        assertFalse(expr.evaluate(taggable("test", List.of("bar"))));
+    }
+
+    @Test
+    public void evaluateMatchesName() {
+        TagExpression expr = TagQueryParser.parse("mytest");
+        assertTrue(expr.evaluate(taggable("mytest", List.of())));
+        assertFalse(expr.evaluate(taggable("other", List.of())));
+    }
+
+    @Test
+    public void evaluateCaseInsensitive() {
+        TagExpression expr = TagQueryParser.parse("FOO");
+        assertTrue(expr.evaluate(taggable("test", List.of("foo"))));
+        assertTrue(expr.evaluate(taggable("test", List.of("FOO"))));
+        assertTrue(expr.evaluate(taggable("test", List.of("Foo"))));
+    }
+
+    @Test
+    public void evaluateNot() {
+        TagExpression expr = TagQueryParser.parse("!foo");
+        assertFalse(expr.evaluate(taggable("test", List.of("foo"))));
+        assertTrue(expr.evaluate(taggable("test", List.of("bar"))));
+    }
+
+    @Test
+    public void evaluateAnd() {
+        TagExpression expr = TagQueryParser.parse("foo && bar");
+        assertTrue(expr.evaluate(taggable("test", List.of("foo", "bar"))));
+        assertFalse(expr.evaluate(taggable("test", List.of("foo"))));
+        assertFalse(expr.evaluate(taggable("test", List.of("bar"))));
+        assertFalse(expr.evaluate(taggable("test", List.of())));
+    }
+
+    @Test
+    public void evaluateOr() {
+        TagExpression expr = TagQueryParser.parse("foo || bar");
+        assertTrue(expr.evaluate(taggable("test", List.of("foo"))));
+        assertTrue(expr.evaluate(taggable("test", List.of("bar"))));
+        assertTrue(expr.evaluate(taggable("test", List.of("foo", "bar"))));
+        assertFalse(expr.evaluate(taggable("test", List.of("baz"))));
+    }
+
+    @Test
+    public void evaluateComplex() {
+        TagExpression expr = TagQueryParser.parse("(!foo && bar) || baz");
+        assertTrue(expr.evaluate(taggable("test", List.of("bar"))));           // bar, no foo → true
+        assertTrue(expr.evaluate(taggable("test", List.of("baz"))));           // baz → true
+        assertTrue(expr.evaluate(taggable("test", List.of("bar", "baz"))));    // both paths true
+        assertFalse(expr.evaluate(taggable("test", List.of("foo", "bar"))));   // foo negates → false
+        assertFalse(expr.evaluate(taggable("test", List.of("foo"))));          // foo only → false
+    }
+
+    @Test
+    public void evaluateInheritsParentTags() {
+        ITaggable parent = taggable("suite", List.of("suite-tag"));
+        ITaggable child = taggable("test", List.of("child-tag"), parent);
+        assertTrue(TagQueryParser.parse("suite-tag").evaluate(child));
+        assertTrue(TagQueryParser.parse("child-tag").evaluate(child));
+        assertFalse(TagQueryParser.parse("other").evaluate(child));
+    }
+
+    @Test
+    public void evaluateDoubleQuotedMultiWordTag() {
+        TagExpression expr = TagQueryParser.parse("\"suite 1\"");
+        assertTrue(expr.evaluate(taggable("suite 1", List.of())));
+        assertFalse(expr.evaluate(taggable("suite 2", List.of())));
+    }
+
+    @Test
+    public void evaluateSingleQuotedMultiWordTag() {
+        TagExpression expr = TagQueryParser.parse("'suite 1'");
+        assertTrue(expr.evaluate(taggable("suite 1", List.of())));
+        assertFalse(expr.evaluate(taggable("suite 2", List.of())));
+    }
+
+    // --- Error cases ---
+
+    @Test
+    public void throwsOnEmptyInput() {
+        assertThrows(IllegalArgumentException.class, () -> TagQueryParser.parse(""));
+        assertThrows(IllegalArgumentException.class, () -> TagQueryParser.parse("   "));
+        assertThrows(IllegalArgumentException.class, () -> TagQueryParser.parse(null));
+    }
+
+    @Test
+    public void throwsOnUnmatchedOpenParen() {
+        TagQueryParseException ex = assertThrows(TagQueryParseException.class,
+                () -> TagQueryParser.parse("(foo"));
+        assertEquals(0, ex.getPosition());
+    }
+
+    @Test
+    public void throwsOnUnmatchedCloseParen() {
+        TagQueryParseException ex = assertThrows(TagQueryParseException.class,
+                () -> TagQueryParser.parse("foo)"));
+        assertEquals(3, ex.getPosition());
+    }
+
+    @Test
+    public void throwsOnUnterminatedString() {
+        TagQueryParseException ex1 = assertThrows(TagQueryParseException.class,
+                () -> TagQueryParser.parse("\"foo"));
+        assertEquals(0, ex1.getPosition());
+
+        TagQueryParseException ex2 = assertThrows(TagQueryParseException.class,
+                () -> TagQueryParser.parse("'foo"));
+        assertEquals(0, ex2.getPosition());
+    }
+
+    @Test
+    public void throwsOnSingleAmpersand() {
+        TagQueryParseException ex = assertThrows(TagQueryParseException.class,
+                () -> TagQueryParser.parse("foo & bar"));
+        assertEquals(4, ex.getPosition());
+    }
+
+    @Test
+    public void throwsOnSinglePipe() {
+        TagQueryParseException ex = assertThrows(TagQueryParseException.class,
+                () -> TagQueryParser.parse("foo | bar"));
+        assertEquals(4, ex.getPosition());
+    }
+
+    @Test
+    public void throwsOnTrailingOperator() {
+        TagQueryParseException ex = assertThrows(TagQueryParseException.class,
+                () -> TagQueryParser.parse("foo &&"));
+        assertEquals(6, ex.getPosition());
+    }
+
+    @Test
+    public void errorMessageContainsCaretPointer() {
+        TagQueryParseException ex = assertThrows(TagQueryParseException.class,
+                () -> TagQueryParser.parse("foo & bar"));
+        String message = ex.getMessage();
+        // Message should contain the query and a caret at position 4 (after "foo ")
+        assertTrue(message.contains("foo & bar"), "message should contain original query");
+        assertTrue(message.contains("^"), "message should contain caret pointer");
+    }
+
+}


### PR DESCRIPTION
Started as `--exclude-tag` but I noticed that there had been some outstanding work on adding complex tag queries. 

I implemented a simple query grammar:
- `!`: NOT 
- `&&`: AND
- `||`: OR

For now I left the `--tag` and `--exclude-tag` as mutually exclusive to the new query system but in theory they could be easily dropped and the new `--tag-query` option used to cover those cases (grammar would just need to be extended to see `,` as `||` I think). 


Would supersede #283
Closes #180 
Closes #255 
Closes #260 
